### PR TITLE
Fix provisioning check inconsistencies and other minor changes

### DIFF
--- a/lib/crypto_port.c
+++ b/lib/crypto_port.c
@@ -244,6 +244,16 @@ int ss_utils_setup_key_helper(size_t key_len, uint8_t key[static key_len], int k
   psa_key_attributes_t key_attributes = PSA_KEY_ATTRIBUTES_INIT;
   psa_key_handle_t key_handle;
 
+  // Check if it exists already, if it does, destroy it so the new one can be imported
+  status = psa_open_key(key_id, &key_handle);
+  if (status == PSA_SUCCESS) {
+    status = psa_destroy_key(key_handle);
+    if (status != PSA_SUCCESS) {
+      LOG_ERR("Failed to destroy a persistent key, ERR: %d", status);
+      return -1;
+    }
+  }
+
   psa_set_key_usage_flags(&key_attributes, usage_flags);
   psa_set_key_algorithm(&key_attributes, alg);
   psa_set_key_type(&key_attributes, key_type);

--- a/lib/fs_port.c
+++ b/lib/fs_port.c
@@ -77,7 +77,7 @@ int init_fs() {
   if (!data && rc) {
     data = SS_ALLOC_N(len * sizeof(uint8_t));
     rc = nvs_read(&fs, DIR_ID, data, len);
-    assert(rc == len);
+    __ASSERT_NO_MSG(rc == len);
   }
 
   ss_list_init(&fs_cache);

--- a/lib/fs_port.c
+++ b/lib/fs_port.c
@@ -390,12 +390,21 @@ int port_remove(const char *path) {
 // list for each { is_name_partial_match? {remove port_remove(cursor->name)} }
 int port_rmdir(const char *) { return 0; }  // todo. Remove all entries with directory match.
 
+static uint8_t default_imsi[] = {0x08, 0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10};
+
 int port_check_provisioned() {
+  int ret;
   uint8_t buffer[IMSI_LEN] = {0};
   struct cache_entry *entry = (struct cache_entry *)f_cache_find_by_name(IMSI_PATH, &fs_cache);
 
-  if (nvs_read(&fs, entry->key, buffer, IMSI_LEN) < 0) {
-    return -1;
+  ret = nvs_read(&fs, entry->key, buffer, IMSI_LEN);
+  if (ret < 0) {
+    return 0;
+  }
+
+  // IMSI read is still the default one from the template
+  if (memcmp(buffer, default_imsi, IMSI_LEN) == 0) {
+    return 0;
   }
 
   return 1;

--- a/lib/include/onomondo/softsim/utils.h
+++ b/lib/include/onomondo/softsim/utils.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <assert.h>
 #include <stdint.h>
 #include <string.h>
+#include <zephyr/kernel.h>
 #include "mem.h"
 
 #define SS_ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
@@ -30,7 +30,7 @@ static inline char *ss_buf_hexdump(const struct ss_buf *buf)
 static inline struct ss_buf *ss_buf_alloc(size_t len)
 {
 	struct ss_buf *sb = SS_ALLOC_N(sizeof(*sb) + len);
-	assert(sb);
+	__ASSERT_NO_MSG(sb);
 
 	sb->data = (uint8_t *) sb + sizeof(*sb);
 	sb->len = len;

--- a/samples/softsim/src/main.c
+++ b/samples/softsim/src/main.c
@@ -44,7 +44,7 @@ static void server_transmission_work_fn(struct k_work *work) {
   char buffer[] = "{\"message\":\"Hello from Onomondo!\"}";
   err = send(client_fd, buffer, sizeof(buffer) - 1, 0);
   if (err < 0) {
-    LOG_ERR("Failed to transmit TCP packet, %d", errno);
+    LOG_ERR("Failed to transmit UDP packet, %d", errno);
 
     k_work_schedule(&server_transmission_work, K_SECONDS(2));
 
@@ -118,9 +118,9 @@ static int server_init(void) {
 static int server_connect(void) {
   int err;
 
-  client_fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  client_fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
   if (client_fd < 0) {
-    LOG_ERR("Failed to create TCP socket: %d\n", errno);
+    LOG_ERR("Failed to create UDP socket: %d\n", errno);
     err = -errno;
     goto error;
   }
@@ -235,14 +235,14 @@ void main(void) {
   LOG_INF("LTE connected!\n");
   err = server_init();
   if (err) {
-    LOG_ERR("Not able to initialize TCP server connection\n");
     return;
+    LOG_ERR("Not able to initialize UDP server connection\n");
   }
 
   err = server_connect();
   if (err) {
-    LOG_ERR("Not able to connect to TCP server\n");
     return;
+    LOG_ERR("Not able to connect to UDP server\n");
   }
 
   k_work_schedule(&server_transmission_work, K_NO_WAIT);

--- a/samples/softsim/src/main.c
+++ b/samples/softsim/src/main.c
@@ -164,14 +164,14 @@ void serial_cb(const struct device *dev, void *user_data) {
   }
 }
 
-void main(void) {
+int main(void) {
   int32_t err;
   LOG_INF("SoftSIM sample started.");
 
   if (!nrf_softsim_check_provisioned()) {
     if (!device_is_ready(uart_dev)) {
       LOG_ERR("UART device not found!");
-      return;
+      return -1;
     }
 
     char *profile_read_from_external_source = k_malloc(PROFILE_SIZE);
@@ -210,7 +210,7 @@ void main(void) {
   err = lte_lc_init();
   if (err) {
     LOG_ERR("Failed to initialize nrf link control, err %d\n", err);
-    return;
+    return -1;
   }
 
   work_init();
@@ -219,13 +219,13 @@ void main(void) {
   err = nrf_modem_at_printf("AT%%CSUS=2");
   if (err) {
     LOG_ERR("Failed to select softsim, err %d\n", err);
-    return;
+    return -1;
   }
 
   err = nrf_modem_at_printf("AT+CFUN=41");
   if (err) {
     LOG_ERR("Failed to activate uicc, err %d\n", err);
-    return;
+    return -1;
   }
 
   modem_connect();
@@ -235,14 +235,14 @@ void main(void) {
   LOG_INF("LTE connected!\n");
   err = server_init();
   if (err) {
-    return;
     LOG_ERR("Not able to initialize UDP server connection\n");
+    return -1;
   }
 
   err = server_connect();
   if (err) {
-    return;
     LOG_ERR("Not able to connect to UDP server\n");
+    return -1;
   }
 
   k_work_schedule(&server_transmission_work, K_NO_WAIT);

--- a/samples/softsim_external_profile/src/main.c
+++ b/samples/softsim_external_profile/src/main.c
@@ -176,7 +176,7 @@ void main(void) {
     }
 
     char *profile_read_from_external_source = k_malloc(PROFILE_SIZE);
-    assert(profile_read_from_external_source != NULL);
+    __ASSERT_NO_MSG(profile_read_from_external_source != NULL);
 
     struct rx_buf_t rx = {
         .buf = profile_read_from_external_source,

--- a/samples/softsim_external_profile/src/main.c
+++ b/samples/softsim_external_profile/src/main.c
@@ -44,7 +44,7 @@ static void server_transmission_work_fn(struct k_work *work) {
   char buffer[] = "{\"message\":\"Hello from Onomondo!\"}";
   err = send(client_fd, buffer, sizeof(buffer) - 1, 0);
   if (err < 0) {
-    LOG_ERR("Failed to transmit TCP packet, %d", errno);
+    LOG_ERR("Failed to transmit UDP packet, %d", errno);
 
     k_work_schedule(&server_transmission_work, K_SECONDS(2));
 
@@ -118,9 +118,9 @@ static int server_init(void) {
 static int server_connect(void) {
   int err;
 
-  client_fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  client_fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
   if (client_fd < 0) {
-    LOG_ERR("Failed to create TCP socket: %d\n", errno);
+    LOG_ERR("Failed to create UDP socket: %d\n", errno);
     err = -errno;
     goto error;
   }
@@ -225,14 +225,14 @@ void main(void) {
   LOG_INF("LTE connected!\n");
   err = server_init();
   if (err) {
-    LOG_ERR("Not able to initialize TCP server connection\n");
     return;
+    LOG_ERR("Not able to initialize UDP server connection\n");
   }
 
   err = server_connect();
   if (err) {
-    LOG_ERR("Not able to connect to TCP server\n");
     return;
+    LOG_ERR("Not able to connect to UDP server\n");
   }
 
   k_work_schedule(&server_transmission_work, K_NO_WAIT);

--- a/samples/softsim_external_profile/src/main.c
+++ b/samples/softsim_external_profile/src/main.c
@@ -165,14 +165,14 @@ void serial_cb(const struct device *dev, void *user_data) {
   }
 }
 
-void main(void) {
+int main(void) {
   int32_t err;
   LOG_INF("SoftSIM sample started.");
 
   if (!nrf_softsim_check_provisioned()) {
     if (!device_is_ready(uart_dev)) {
       LOG_ERR("UART device not found!");
-      return;
+      return -1;
     }
 
     char *profile_read_from_external_source = k_malloc(PROFILE_SIZE);
@@ -213,7 +213,7 @@ void main(void) {
   err = lte_lc_init();
   if (err) {
     LOG_ERR("Failed to initialize nrf link control, err %d\n", err);
-    return;
+    return -1;
   }
 
   work_init();
@@ -225,14 +225,14 @@ void main(void) {
   LOG_INF("LTE connected!\n");
   err = server_init();
   if (err) {
-    return;
     LOG_ERR("Not able to initialize UDP server connection\n");
+    return -1;
   }
 
   err = server_connect();
   if (err) {
-    return;
     LOG_ERR("Not able to connect to UDP server\n");
+    return -1;
   }
 
   k_work_schedule(&server_transmission_work, K_NO_WAIT);

--- a/samples/softsim_static_profile/src/main.c
+++ b/samples/softsim_static_profile/src/main.c
@@ -39,7 +39,7 @@ static void server_transmission_work_fn(struct k_work *work) {
   char buffer[] = "{\"message\":\"Hello from Onomondo!\"}";
   err = send(client_fd, buffer, sizeof(buffer) - 1, 0);
   if (err < 0) {
-    LOG_ERR("Failed to transmit TCP packet, %d", errno);
+    LOG_ERR("Failed to transmit UDP packet, %d", errno);
 
     k_work_schedule(&server_transmission_work, K_SECONDS(2));
 
@@ -113,9 +113,9 @@ static int server_init(void) {
 static int server_connect(void) {
   int err;
 
-  client_fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  client_fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
   if (client_fd < 0) {
-    LOG_ERR("Failed to create TCP socket: %d\n", errno);
+    LOG_ERR("Failed to create UDP socket: %d\n", errno);
     err = -errno;
     goto error;
   }
@@ -155,14 +155,14 @@ void main(void) {
   LOG_INF("LTE connected!\n");
   err = server_init();
   if (err) {
-    LOG_ERR("Not able to initialize TCP server connection\n");
     return;
+    LOG_ERR("Not able to initialize UDP server connection\n");
   }
 
   err = server_connect();
   if (err) {
-    LOG_ERR("Not able to connect to TCP server\n");
     return;
+    LOG_ERR("Not able to connect to UDP server\n");
   }
 
   k_work_schedule(&server_transmission_work, K_NO_WAIT);

--- a/samples/softsim_static_profile/src/main.c
+++ b/samples/softsim_static_profile/src/main.c
@@ -134,14 +134,14 @@ error:
   return err;
 }
 
-void main(void) {
+int main(void) {
   int32_t err;
   LOG_INF("SoftSIM sample started.");
 
   err = lte_lc_init();
   if (err) {
     LOG_ERR("Failed to initialize nrf link control, err %d\n", err);
-    return;
+    return -1;
   }
 
   work_init();
@@ -155,14 +155,14 @@ void main(void) {
   LOG_INF("LTE connected!\n");
   err = server_init();
   if (err) {
-    return;
     LOG_ERR("Not able to initialize UDP server connection\n");
+    return -1;
   }
 
   err = server_connect();
   if (err) {
-    return;
     LOG_ERR("Not able to connect to UDP server\n");
+    return -1;
   }
 
   k_work_schedule(&server_transmission_work, K_NO_WAIT);


### PR DESCRIPTION
This PR addresses some issues regarding connectivity caused by improper provisioning steps.

When flashing a new firmware, the device can be in two states:
* The keys in `tfm_storage` have been provisioned already
* No keys provisioned in the `tfm_storage`

When flashing a new firmware and bundling a SIM profile template, we are also overwriting the NVS file system that contains some of the SIM profile information. Flashing does not erase the `tfm_storage` partition so previous keys may still be present.
We want to provision when the profile template has not been provisioned (so it contains still default values). If we provision when there are already provisioned keys in the `tfm_storage`, with the current implementation we will get errors because the keys exist already. They also may be inconsistent with the current profile being checked/provisioned. To fix this, during provisioning step, always delete KI, KIC, KID and import the new ones that are guaranteed to be compatible with the new profile. This change introduces a coupling between the `nvs_storage` part of the profile and the `tfm_storage` part.
This change is working under the assumption that the default (unprovisioned) IMSI when flashing a "fresh" template is always: `[0x08, 0x09, 0x10, 0x10, 0x00, 0x00, 0x00, 0x00, 0x10]` (@peterbornerup please correct me if this assumption is wrong).

Other minor changes:
* Add missed Zephyr asserts
* Fix samples not connecting to server `1.2.3.4:4321` when using TCP
* Make `main` function signature Zephyr compliant (return `void` to `int`)

With these changes the samples can now attach correctly to the network and connect successfully to the server.