### PR TITLE
fix: 🐛 Heap corrupted by de-initializing softsim many times

### DIFF
--- a/lib/fs_port.c
+++ b/lib/fs_port.c
@@ -88,7 +88,7 @@ int init_fs() {
   fs_is_initialized++;
 
 out:
-  free(data);
+  SS_FREE(data);
   return ss_list_empty(&fs_cache);
 }
 


### PR DESCRIPTION
A buffer in the file-system wrapper was wrongly freed using a libc implementation instead of the k_free causing the heap to be corrupted over time.

A heap trace was installed to verify that all memory associated with softsim is correctly freed:

After toggling softsim 50 times the heap was still fully available
```
INFO: Allocated Heap = 32
INFO: Free Heap = 29864
INFO: Max Allocated Heap = 17232
```