### PR TITLE
Auto append softsim overlay fragment to the samples

### DIFF
--- a/samples/softsim_external_profile/CMakeLists.txt
+++ b/samples/softsim_external_profile/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-list(APPEND OVERLAY_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/../../overlay-softsim.conf")
+list(APPEND OVERLAY_CONFIG "$ENV{ZEPHYR_BASE}/../modules/lib/onomondo-softsim/overlay-softsim.conf")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(softsim)

--- a/samples/softsim_external_profile/CMakeLists.txt
+++ b/samples/softsim_external_profile/CMakeLists.txt
@@ -6,6 +6,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
+list(APPEND OVERLAY_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/../../overlay-softsim.conf")
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(softsim)
 

--- a/samples/softsim_static_profile/CMakeLists.txt
+++ b/samples/softsim_static_profile/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-list(APPEND OVERLAY_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/../../overlay-softsim.conf")
+list(APPEND OVERLAY_CONFIG "$ENV{ZEPHYR_BASE}/../modules/lib/onomondo-softsim/overlay-softsim.conf")
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(softsim)

--- a/samples/softsim_static_profile/CMakeLists.txt
+++ b/samples/softsim_static_profile/CMakeLists.txt
@@ -6,6 +6,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
+list(APPEND OVERLAY_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/../../overlay-softsim.conf")
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(softsim)
 


### PR DESCRIPTION
PR #32 removed some configuration options from the samples which were also duplicated in the `overlay-softsim.conf`.

This change requires that the `overlay-softsim.conf` is added as a kconfig fragment in order to build either of the samples. 

This PR auto appends that kconfig overlay fragment for each of the examples.
