### PR TITLE
ci: upgrade version of zephyr build container from 0.26.12 to 0.26.13

### DIFF
--- a/.github/workflows/softsim-zephyr-rtos-ci.yml
+++ b/.github/workflows/softsim-zephyr-rtos-ci.yml
@@ -11,7 +11,7 @@ jobs:
   build-in-zyphyr-ci-container:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    container: ghcr.io/zephyrproject-rtos/ci:v0.26.12
+    container: ghcr.io/zephyrproject-rtos/ci:v0.26.13
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
 


### PR DESCRIPTION
Following the latests release of https://github.com/zephyrproject-rtos/docker-image/releases/tag/v0.26.13