### PR TITLE
fix: improve support for Thingy91

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,3 +31,8 @@ if(CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX)
   )
 endif()
 endif()
+
+# Override the default NCS static partition layout for the Thingy91
+if(CONFIG_THINGY91_STATIC_PARTITIONS_FACTORY)
+  set(PM_STATIC_YML_FILE ${CMAKE_CURRENT_LIST_DIR}/thingy91_pm_static.yml CACHE INTERNAL "")
+endif()

--- a/thingy91_pm_static.yml
+++ b/thingy91_pm_static.yml
@@ -1,0 +1,246 @@
+EMPTY_0:
+  address: 0xfc000
+  end_address: 0xfe000
+  region: flash_primary
+  size: 0x2000
+EMPTY_1:
+  address: 0x6a000
+  end_address: 0x70000
+  placement:
+    after:
+    - tfm_its
+  region: flash_primary
+  size: 0x6000
+EMPTY_2:
+  address: 0x72000
+  end_address: 0x75000
+  size: 0x3000
+app:
+  address: 0x20000
+  end_address: 0x60000
+  region: flash_primary
+  size: 0x3e000
+mcuboot:
+  address: 0x0
+  end_address: 0xc000
+  placement:
+    before:
+    - mcuboot_primary
+  region: flash_primary
+  size: 0xc000
+mcuboot_pad:
+  address: 0xc000
+  end_address: 0xc200
+  placement:
+    align:
+      start: 0x1000
+    before:
+    - mcuboot_primary_app
+  region: flash_primary
+  size: 0x200
+mcuboot_primary:
+  address: 0xc000
+  end_address: 0x75000
+  region: flash_primary
+  size: 0x69000
+  span:
+  - tfm
+  - mcuboot_pad
+  - app
+mcuboot_primary_app:
+  address: 0xc200
+  end_address: 0x75000
+  region: flash_primary
+  size: 0x68e00
+  span:
+  - app
+  - tfm
+mcuboot_scratch:
+  address: 0xde000
+  end_address: 0xfc000
+  placement:
+    after:
+    - app
+    align:
+      start: 0x1000
+  region: flash_primary
+  size: 0x1e000
+mcuboot_secondary:
+  address: 0x75000
+  end_address: 0xde000
+  placement:
+    after:
+    - mcuboot_primary
+    align:
+      start: 0x1000
+  region: flash_primary
+  share_size:
+  - mcuboot_primary
+  size: 0x69000
+mcuboot_sram:
+  address: 0x20000000
+  end_address: 0x20016000
+  orig_span: &id001
+  - tfm_sram
+  region: sram_primary
+  size: 0x16000
+  span: *id001
+nonsecure_storage:
+  address: 0xfe000
+  end_address: 0x100000
+  region: flash_primary
+  size: 0x2000
+  span:
+  - settings_storage
+nrf_modem_lib_ctrl:
+  address: 0x20016000
+  end_address: 0x200164e8
+  inside:
+  - sram_nonsecure
+  placement:
+    after:
+    - tfm_sram
+    - start
+  region: sram_primary
+  size: 0x4e8
+nrf_modem_lib_rx:
+  address: 0x20018568
+  end_address: 0x2001a568
+  inside:
+  - sram_nonsecure
+  placement:
+    after:
+    - nrf_modem_lib_tx
+  region: sram_primary
+  size: 0x2000
+nrf_modem_lib_sram:
+  address: 0x20016000
+  end_address: 0x2001a568
+  orig_span: &id002
+  - nrf_modem_lib_ctrl
+  - nrf_modem_lib_tx
+  - nrf_modem_lib_rx
+  region: sram_primary
+  size: 0x4568
+  span: *id002
+nrf_modem_lib_tx:
+  address: 0x200164e8
+  end_address: 0x20018568
+  inside:
+  - sram_nonsecure
+  placement:
+    after:
+    - nrf_modem_lib_ctrl
+  region: sram_primary
+  size: 0x2080
+nvs_storage:
+  address: 0x60000
+  end_address: 0x68000
+  placement:
+    align:
+      start: 0x8000
+    before:
+    - tfm_storage
+    - end
+  region: flash_primary
+  size: 0x8000
+otp:
+  address: 0xff8108
+  end_address: 0xff83fc
+  region: otp
+  size: 0x2f4
+settings_storage:
+  address: 0xfe000
+  end_address: 0x100000
+  placement:
+    after:
+    - mcuboot_scratch
+  region: flash_primary
+  size: 0x2000
+sram_nonsecure:
+  address: 0x20016000
+  end_address: 0x20040000
+  orig_span: &id003
+  - sram_primary
+  - nrf_modem_lib_ctrl
+  - nrf_modem_lib_tx
+  - nrf_modem_lib_rx
+  region: sram_primary
+  size: 0x2a000
+  span: *id003
+sram_primary:
+  address: 0x2001a568
+  end_address: 0x20040000
+  region: sram_primary
+  size: 0x25a98
+sram_secure:
+  address: 0x20000000
+  end_address: 0x20016000
+  orig_span: &id004
+  - tfm_sram
+  region: sram_primary
+  size: 0x16000
+  span: *id004
+tfm:
+  address: 0xc200
+  end_address: 0x20000
+  region: flash_primary
+  size: 0x13e00
+tfm_its:
+  address: 0x68000
+  end_address: 0x6a000
+  inside:
+  - tfm_storage
+  placement:
+    align:
+      start: 0x8000
+    before:
+    - tfm_otp_nv_counters
+  region: flash_primary
+  size: 0x2000
+tfm_nonsecure:
+  address: 0x20000
+  end_address: 0x73000
+  region: flash_primary
+  size: 0x53000
+  span:
+  - app
+tfm_otp_nv_counters:
+  address: 0x70000
+  end_address: 0x72000
+  inside:
+  - tfm_storage
+  placement:
+    align:
+      start: 0x8000
+    before:
+    - end
+  region: flash_primary
+  size: 0x2000
+tfm_secure:
+  address: 0xc000
+  end_address: 0x20000
+  region: flash_primary
+  size: 0x14000
+  span:
+  - mcuboot_pad
+  - tfm
+tfm_sram:
+  address: 0x20000000
+  end_address: 0x20016000
+  inside:
+  - sram_secure
+  placement:
+    after:
+    - start
+  region: sram_primary
+  size: 0x16000
+tfm_storage:
+  address: 0x68000
+  end_address: 0x72000
+  orig_span: &id005
+  - tfm_its
+  - tfm_otp_nv_counters
+  region: flash_primary
+  size: 0xa000
+  span: *id005


### PR DESCRIPTION
This commit addresses an issue where the samples do not compile out of the box for the Thingy91 due to an overflow of the TFM partition. Starting from the factory static partition layout, resize the `tfm` partition to be large enough to satisfy the new size requirements introduced by SoftSIM and update the other related addresses and sizes accordingly.

This addresses https://github.com/onomondo/nrf-softsim/issues/49