### PR TITLE
ci: add thingy91 nrf9160 build as part of ci

### DIFF
--- a/.github/workflows/softsim-zephyr-rtos-ci.yml
+++ b/.github/workflows/softsim-zephyr-rtos-ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        board: [nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns, nrf9151dk_nrf9151_ns, actinius_icarus_ns]
+        board: [nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns, nrf9151dk_nrf9151_ns, thingy91_nrf9160_ns, actinius_icarus_ns]
 
     steps:
       - name: Initialize workspace


### PR DESCRIPTION
A static partitioning scheme has been introduced to allow SoftSIM to be build for the nRF9160 SiP Thingy:91.

This PR makes the Thingy:91 part of the supported SoftSIM devices, and we would like to ensure that we are not breaking the compatibility in the future, therefor this PR.