### PR TITLE
ci: add artifacts to releases automatically

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,3 +1,5 @@
+name: Run release-please
+
 on:
   push:
     branches:
@@ -6,8 +8,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-
-name: Run release-please
 
 jobs:
   release-please:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        board: [nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns, nrf9151dk_nrf9151_ns, actinius_icarus_ns]
+        board: [nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns, nrf9151dk_nrf9151_ns]
 
     steps:
       - uses: googleapis/release-please-action@v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,12 +9,25 @@ permissions:
 
 name: Run release-please
 
+
 jobs:
   release-please:
+
     runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    strategy:
+      matrix:
+        board: [nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns, nrf9151dk_nrf9151_ns, actinius_icarus_ns]
+
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: simple
           package-name: ${{ github.event.repository.name }}
+      - name: Upload Release Artifact
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ steps.release.outputs.tag_name }} ./artifact/softsim_external_profile_${{ matrix.board }}.zip

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,12 +9,11 @@ permissions:
 
 name: Run release-please
 
-
 jobs:
   release-please:
-
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: build-in-zyphyr-ci-container
 
     strategy:
       matrix:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           release-type: simple
           package-name: ${{ github.event.repository.name }}
+    outputs:
+      tag: ${{ steps.release.outputs.tag_name }}
+      release_created: ${{ steps.release.outputs.release_created }}
 
   # Add build artifacts to the new GitHub release
   release-artifacts:
@@ -36,6 +39,7 @@ jobs:
         with:
           name: softsim_external_profile_${{ matrix.board }}
       - name: Upload Release Artifact
+        if: ${{ needs.release-please.outputs.release_created == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.release.outputs.tag_name }} softsim_external_profile_${{ matrix.board }}.zip
+        run: gh release upload ${{ needs.release-please.outputs.tag }} softsim_external_profile_${{ matrix.board }}.zip

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  release-please:
+  create-release:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -27,7 +27,7 @@ jobs:
   release-artifacts:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [build-in-zyphyr-ci-container, release-please]
+    needs: [build-in-zyphyr-ci-container, create-release]
 
     strategy:
       matrix:
@@ -39,7 +39,7 @@ jobs:
         with:
           name: softsim_external_profile_${{ matrix.board }}
       - name: Upload Release Artifact
-        if: ${{ needs.release-please.outputs.release_created == 'true' }}
+        if: ${{ needs.create-release.outputs.release_created == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ needs.release-please.outputs.tag }} softsim_external_profile_${{ matrix.board }}.zip
+        run: gh release upload ${{ needs.create-release.outputs.tag }} softsim_external_profile_${{ matrix.board }}.zip

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: simple
           package-name: ${{ github.event.repository.name }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,7 +1,7 @@
----
 on:
   push:
-    branches: [master]
+    branches:
+      - master
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,20 +13,25 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: build-in-zyphyr-ci-container
-
-    strategy:
-      matrix:
-        board: [nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns, nrf9151dk_nrf9151_ns]
-
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: simple
           package-name: ${{ github.event.repository.name }}
+
+  # Add build artifacts to the new GitHub release
+  release-artifacts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [build-in-zyphyr-ci-container, release-please]
+
+    strategy:
+      matrix:
+        board: [nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns, nrf9151dk_nrf9151_ns]
+
+    steps:
       - name: Upload Release Artifact
-        if: ${{ steps.release.outputs.release_created }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ steps.release.outputs.tag_name }} ./artifact/softsim_external_profile_${{ matrix.board }}.zip

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,11 @@ jobs:
         board: [nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns, nrf9151dk_nrf9151_ns]
 
     steps:
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: softsim_external_profile_${{ matrix.board }}
       - name: Upload Release Artifact
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.release.outputs.tag_name }} ./artifact/softsim_external_profile_${{ matrix.board }}.zip
+        run: gh release upload ${{ steps.release.outputs.tag_name }} softsim_external_profile_${{ matrix.board }}.zip

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,9 +25,10 @@ jobs:
 
   # Add build artifacts to the new GitHub release
   release-artifacts:
+    needs: [build-in-zyphyr-ci-container, create-release]
+    if: ${{ needs.create-release.outputs.release_created }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: [build-in-zyphyr-ci-container, create-release]
 
     strategy:
       matrix:
@@ -39,7 +40,6 @@ jobs:
         with:
           name: softsim_external_profile_${{ matrix.board }}
       - name: Upload Release Artifact
-        if: ${{ needs.create-release.outputs.release_created == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ needs.create-release.outputs.tag }} softsim_external_profile_${{ matrix.board }}.zip

--- a/.github/workflows/softsim-zephyr-rtos-ci.yml
+++ b/.github/workflows/softsim-zephyr-rtos-ci.yml
@@ -47,6 +47,7 @@ jobs:
           path: modules/lib/onomondo-softsim/samples/softsim_external_profile/build/zephyr/merged.hex
           overwrite: true
           retention-days: 90
+          if-no-files-found: error
 
       - name: Build RAM and ROM report for static profile sample
         working-directory: modules/lib/onomondo-softsim/samples/softsim_static_profile

--- a/.github/workflows/softsim-zephyr-rtos-ci.yml
+++ b/.github/workflows/softsim-zephyr-rtos-ci.yml
@@ -25,10 +25,21 @@ jobs:
         board: [nrf9160dk_nrf9160_ns, nrf9161dk_nrf9161_ns, nrf9151dk_nrf9151_ns, thingy91_nrf9160_ns, actinius_icarus_ns]
 
     steps:
+      # Initialize a Zephyr West workspace in its default format
       - name: Initialize workspace
         run: |
           west init -m https://github.com/${GITHUB_REPOSITORY}
-          west update -o=--depth=1 -n
+
+      # Ensure that the checkout follows only this build sha and not the master branch
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: modules/lib/onomondo-softsim
+
+      # Update dependecies and submodules using west
+      - name: Fetch nRF and Zephyr workspaces and dependecies
+        run: |
+          west update -o=--depth=1 --narrow
 
       - name: Build firmware of static profile sample
         working-directory: modules/lib/onomondo-softsim/samples/softsim_static_profile

--- a/.github/workflows/softsim-zephyr-rtos-ci.yml
+++ b/.github/workflows/softsim-zephyr-rtos-ci.yml
@@ -1,3 +1,5 @@
+name: SoftSIM for nRF91 Build
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
When running the release-please workflow, we would like the build artifacts of the release build itself to be stored within the release tag.

This will allow us to link to builds targeting all supported hardware platforms, allowing users to easily test and validate SoftSIM without the requirement of setting up the entire Nordic/West build environment.