### PR TITLE
build: update nordic sdk build system from v2.6.1 to v2.6.2

### DIFF
--- a/.github/workflows/softsim-zephyr-rtos-ci.yml
+++ b/.github/workflows/softsim-zephyr-rtos-ci.yml
@@ -14,7 +14,7 @@ jobs:
   build-in-zyphyr-ci-container:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    container: ghcr.io/zephyrproject-rtos/ci:v0.26.14
+    container: ghcr.io/zephyrproject-rtos/ci:v0.26.18
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# nrf-softsim
+# Onomondo SoftSIM for Nordic nRF91 Series
+
+> [!IMPORTANT]
+> This repository is currently supporting nRF Connect SDK v2.5.1 to v2.6.2.
+>
+> The repository is not yet ported to sysbuild, introduced in nRF Connect SDK v2.7.0.
+>
+> Feel free to contribute to this repository if you have already done the migration to sysbuild.
+
 #### Table of Contents
 ##### Quickstart
 1. [Configure NCS to include SoftSIM libraries in your build system](#setup)

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: sdk-nrf
       path: nrf
-      revision: v2.6.1
+      revision: v2.6.2
       remote: nrfconnect
       import: true
   self:


### PR DESCRIPTION
A small nRF Connect SDK version bump from v2.6.1 to v2.6.2.
Ensuring that the readme of the repository includes a statement of the lack of support for Sysbuild at the moment.