### PR TITLE
ci: bump ubuntu to v24.04 and zephyr docker to v0.27.4

### DIFF
--- a/.github/workflows/softsim-zephyr-rtos-ci.yml
+++ b/.github/workflows/softsim-zephyr-rtos-ci.yml
@@ -12,9 +12,9 @@ concurrency:
 
 jobs:
   build-in-zyphyr-ci-container:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
-    container: ghcr.io/zephyrproject-rtos/ci:v0.26.18
+    container: ghcr.io/zephyrproject-rtos/ci:v0.27.4
     env:
       CMAKE_PREFIX_PATH: /opt/toolchains
 


### PR DESCRIPTION
Ensuring that the GitHub Actions dependencies is kept up to date.

This PR includes changes to:
- GitHub actions host version bump from ubuntu-22.04 to ubuntu-24.04
- Zephyr CI Docker image version bump from v0.26.18 to v0.27.4