### PR TITLE
ci: simplify github actions and fix release please

### DIFF
--- a/.github/workflows/artifact-release.yml
+++ b/.github/workflows/artifact-release.yml
@@ -1,0 +1,46 @@
+name: Release Artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag'
+        required: true
+        default: v5.0.0
+      run_id:
+        description: 'Run ID'
+        required: true
+        default: '13908029974'
+
+jobs:
+  release-artifacts:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    strategy:
+      matrix:
+        board: [nrf9160dk/nrf9160/ns, nrf9161dk/nrf9161/ns, nrf9151dk/nrf9151/ns, thingy91/nrf9160/ns]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Archive name generator
+        id: artifact_name
+        run: echo "artifact_name=$(echo ${{ matrix.board }} | tr "/" "_")" >> $GITHUB_OUTPUT
+
+      - name: Download Build Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.artifact_name.outputs.artifact_name }}
+          run-id: ${{ github.event.inputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Release Artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          zip -v ${{ steps.artifact_name.outputs.artifact_name }}.zip merged.hex
+          gh release upload ${{ github.event.inputs.release_tag }} ${{ steps.artifact_name.outputs.artifact_name }}.zip

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,15 +1,17 @@
----
-name: Lint commit messages
-on:
-  pull_request:
+name: Lint Commit Messages
+
+on: pull_request
 
 jobs:
   commitlint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        name: Checkout source code
+    runs-on: ubuntu-24.04
 
-      - uses: wagoid/commitlint-github-action@v5
-        name: Lint commit messages
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Linting commit messages
+        uses: wagoid/commitlint-github-action@v5
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: Run release-please
+name: Release Please
 
 on:
   push:
@@ -11,39 +11,12 @@ permissions:
 
 jobs:
   create-release:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: simple
-          package-name: ${{ github.event.repository.name }}
-    outputs:
-      tag: ${{ steps.release.outputs.tag_name }}
-      release_created: ${{ steps.release.outputs.release_created }}
-
-  # Add build artifacts to the new GitHub release
-  release-artifacts:
-    needs: [build-in-docker-container, create-release]
-    if: ${{ needs.create-release.outputs.release_created }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-
-    strategy:
-      matrix:
-        board: [nrf9160dk/nrf9160/ns, nrf9161dk/nrf9161/ns, nrf9151dk/nrf9151/ns]
-
-    steps:
-      - name: Archive name generator
-        id: artifact_name
-        run: echo "artifact_name=$(echo ${{ matrix.board }} | tr "/" "_")" >> $GITHUB_OUTPUT
-
-      - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ steps.artifact_name.outputs.artifact_name }}
-      - name: Upload Release Artifact
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ needs.create-release.outputs.tag }} ${{ steps.artifact_name.outputs.artifact_name }}.zip
+          target-branch: master


### PR DESCRIPTION
This PR seek to fix release please, that are currently not working as intended.
And create a workflow that can be manually triggered when we want to add build artifacts to releases (this feature is limited to users with write access to the repository)

This pull request includes several updates to GitHub Actions workflows, primarily focusing on renaming workflows, updating the runner version, and adding a new workflow for releasing artifacts. The most important changes include the addition of a new artifact release workflow.