### PR TITLE
ci: add Nordic Thingy:91 X to github actions

### DIFF
--- a/.github/workflows/artifact-release.yml
+++ b/.github/workflows/artifact-release.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        board: [nrf9160dk/nrf9160/ns, nrf9161dk/nrf9161/ns, nrf9151dk/nrf9151/ns, thingy91/nrf9160/ns]
+        board: [nrf9160dk/nrf9160/ns, nrf9161dk/nrf9161/ns, nrf9151dk/nrf9151/ns, thingy91/nrf9160/ns, thingy91x/nrf9151/ns]
 
     steps:
       - name: Checkout
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Archive name generator
+      - name: Artifact name generator
         id: artifact_name
         run: echo "artifact_name=$(echo ${{ matrix.board }} | tr "/" "_")" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -1,12 +1,10 @@
 name: SoftSIM for nRF91 Build
 
 on:
-  pull_request:
-    branches:
-      - master
   push:
     branches:
       - master
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,8 +22,9 @@ jobs:
         shell: bash
 
     strategy:
+      fail-fast: false
       matrix:
-        board: [nrf9160dk/nrf9160/ns, nrf9161dk/nrf9161/ns, nrf9151dk/nrf9151/ns, thingy91/nrf9160/ns]
+        board: [nrf9160dk/nrf9160/ns, nrf9161dk/nrf9161/ns, nrf9151dk/nrf9151/ns, thingy91/nrf9160/ns, thingy91x/nrf9151/ns]
 
     steps:
       # Initialize a Zephyr West workspace in its default format
@@ -39,8 +38,8 @@ jobs:
         with:
           path: modules/lib/onomondo-softsim
 
-      # Update dependecies and submodules using west
-      - name: Fetch nRF and Zephyr workspaces and dependecies
+      # Update dependencies and submodules using west
+      - name: Fetch nRF and Zephyr workspaces and dependencies
         run: |
           west update -o=--depth=1 --narrow
 


### PR DESCRIPTION
This pull request includes updates to the GitHub workflow configurations for artifact release and SoftSIM builds. The changes primarily focus on adding support for a new board and adjusting the configuration to improve build processes.

Updates to GitHub workflows:

* [`.github/workflows/artifact-release.yml`](diffhunk://#diff-96031f7386fadc565ac9625f6ddc622847237959704bc6ba9fd221aa2288a803L22-R22): Added support for the `thingy91x/nrf9151/ns` board in the matrix strategy.
* `.github/workflows/softsim-build-using-docker.yml`: 
  * Re-enabled `pull_request` trigger for the workflow.
  * Added `fail-fast: false` to the strategy to ensure that all matrix jobs are completed even if one fails.
  * Added support for the `thingy91x/nrf9151/ns` board in the matrix strategy.