### PR TITLE
chore: bump nrf sdk to v3.0.2

### DIFF
--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -14,7 +14,7 @@ jobs:
   build-in-docker-container:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v3.0.1
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v3.0.2
     defaults:
       run:
         # Bash shell is needed to set toolchain related environment variables in docker container

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: sdk-nrf
       path: nrf
-      revision: v3.0.1
+      revision: v3.0.2
       remote: nrfconnect
       import: true
   self:


### PR DESCRIPTION
This pull request includes updates to align the project with the latest version of the SDK toolchain. The changes ensure consistency across the build environment and project manifest.

Updates to SDK toolchain version:

* [`.github/workflows/softsim-build-using-docker.yml`](diffhunk://#diff-4cf60db72f196df59342541a5103a7b6c4cbea2b915eefcfe51eb40b03fe4119L17-R17): Updated the Docker container image to use `ghcr.io/nrfconnect/sdk-nrf-toolchain:v3.0.2` instead of `v3.0.1`.
* [`west.yml`](diffhunk://#diff-d7f4082837dc3cb270fcf1abd68188216fdadee294e01611b8ca59ddea7fdbb3L8-R8): Updated the `sdk-nrf` project revision to `v3.0.2` to match the updated toolchain version.