### PR TITLE
feat: Preprovisioned Sample

### DIFF
--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -53,6 +53,11 @@ jobs:
         run: |
           west build --sysbuild --pristine=always --board ${{ matrix.board }}
 
+      - name: Build firmware of preprovisioned profile sample
+        working-directory: modules/lib/onomondo-softsim/samples/softsim_preprovisioned_profile
+        run: |
+          west build --sysbuild --pristine=always --board ${{ matrix.board }}
+
       - name: Archive name generator
         id: artifact_name
         run: echo "artifact_name=$(echo ${{ matrix.board }} | tr "/" "_")" >> $GITHUB_OUTPUT

--- a/samples/softsim_external_profile/pm_static.yml
+++ b/samples/softsim_external_profile/pm_static.yml
@@ -1,3 +1,11 @@
+nvs_storage:
+  address: 0xf0000
+  size: 0x8000
+nonsecure_storage:
+  address: 0xf0000
+  span:
+  - nvs_storage
+  size: 0x8000
 tfm_its:
   address: 0xf8000
   size: 0x2000

--- a/samples/softsim_preprovisioned_profile/CMakeLists.txt
+++ b/samples/softsim_preprovisioned_profile/CMakeLists.txt
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+
+list(APPEND OVERLAY_CONFIG "$ENV{ZEPHYR_BASE}/../modules/lib/onomondo-softsim/overlay-softsim.conf")
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(softsim)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/softsim_preprovisioned_profile/README.md
+++ b/samples/softsim_preprovisioned_profile/README.md
@@ -1,0 +1,9 @@
+  # Instructions
+  This sample is based on the `softsim_static_profile` with the static profile from `prj.conf` removed and `SB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX` disabled.
+
+  Before using this sample on a device, that device must be first provisioned using one of the other samples.
+  The sample will fault if the device has not already been provisioned.
+
+  Building with `SB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX`enabled adds a section which initialises the flash partition `nonsecure_storage/nvs_storage`. However, for already provisioned devices, this re-initialisation will erase any existing provisioning data.
+
+  Building without enabling `SB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX` will preserve the existing provisioning data, providing the flash partition `nonsecure_storage/nvs_storage` is at the same location.

--- a/samples/softsim_preprovisioned_profile/pm_static.yml
+++ b/samples/softsim_preprovisioned_profile/pm_static.yml
@@ -1,0 +1,24 @@
+nvs_storage:
+  address: 0xf0000
+  size: 0x8000
+nonsecure_storage:
+  address: 0xf0000
+  span:
+  - nvs_storage
+  size: 0x8000
+tfm_its:
+  address: 0xf8000
+  size: 0x2000
+tfm_otp_nv_counters:
+  address: 0xfa000
+  size: 0x2000
+EMPTY_tfm_ps:
+  address: 0xfc000
+  size: 0x4000
+tfm_storage:
+  address: 0xf8000
+  span:
+  - EMPTY_tfm_ps
+  - tfm_its
+  - tfm_otp_nv_counters
+  size: 0x8000

--- a/samples/softsim_preprovisioned_profile/prj.conf
+++ b/samples/softsim_preprovisioned_profile/prj.conf
@@ -1,0 +1,48 @@
+### Onomondo SoftSIM ###
+CONFIG_SOFTSIM_DEBUG=n
+CONFIG_SOFTSIM_LOG_LEVEL_ERR=y
+### Onomondo SoftSIM ###
+
+# Log Configurations
+CONFIG_DEBUG=n
+CONFIG_LOG=y
+CONFIG_NRF_MODEM_LOG=n
+
+# General Configurations
+CONFIG_LOG_BUFFER_SIZE=5000
+CONFIG_LOG_PROCESS_TRIGGER_THRESHOLD=5
+CONFIG_LOG_DEFAULT_LEVEL=1
+
+# Modem Configurations
+CONFIG_NRF_MODEM_LIB=y
+
+# NET Configurations
+CONFIG_NETWORKING=y
+CONFIG_NET_SOCKETS=y
+CONFIG_NET_NATIVE=n
+CONFIG_NET_SOCKETS_OFFLOAD=y
+CONFIG_POSIX_API=y
+
+# LTE Configurations
+CONFIG_LTE_LINK_CONTROL=y
+CONFIG_LTE_LC_PSM_MODULE=y
+CONFIG_LTE_LC_EDRX_MODULE=y
+
+# AT host library
+CONFIG_SERIAL=y
+CONFIG_AT_HOST_LIBRARY=y
+CONFIG_UART_INTERRUPT_DRIVEN=y
+
+# Reduce the size of TF-M by disabling the PS
+CONFIG_TFM_PARTITION_PROTECTED_STORAGE=n
+CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n
+
+# Reduce the size of the TF-M partition
+# when combined with static partitioning
+CONFIG_PM_PARTITION_SIZE_TFM=0x10000
+
+# The bootloader adds a small mcuboot_pad partition,
+# whose size must be subtracted from the TF-M partition
+#CONFIG_BOOTLOADER_MCUBOOT=y
+#CONFIG_PM_PARTITION_SIZE_TFM=0xFE00
+

--- a/samples/softsim_preprovisioned_profile/src/main.c
+++ b/samples/softsim_preprovisioned_profile/src/main.c
@@ -1,0 +1,175 @@
+#include <stdio.h>
+#include <string.h>
+
+#include <nrf_modem.h>
+#include <nrf_modem_at.h>
+#include <nrf_softsim.h>
+
+#include <pm_config.h>
+
+#include <modem/lte_lc.h>
+#include <modem/nrf_modem_lib.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/nrf_clock_control.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/sys/reboot.h>
+
+LOG_MODULE_REGISTER(softsim_sample, LOG_LEVEL_INF);
+
+// semaphores
+K_SEM_DEFINE(lte_connected, 0, 1);	// semaphore to signal that the LTE connection is established
+
+static void lte_handler(const struct lte_lc_evt *const evt);
+static int server_connect(void);
+
+static int client_fd;
+static struct sockaddr_storage host_addr;
+static struct k_work_delayable server_transmission_work;
+
+
+static void server_transmission_work_fn(struct k_work *work)
+{
+  char buffer[] = "{\"message\":\"Hello from Onomondo!\"}";
+
+  int err = send(client_fd, buffer, sizeof(buffer) - 1, 0);
+
+  if (err < 0) {
+    LOG_ERR("Failed to transmit UDP packet, %d", errno);
+    k_work_schedule(&server_transmission_work, K_SECONDS(2));
+    return;
+  }
+
+  k_work_schedule(&server_transmission_work, K_SECONDS(150));
+}
+
+static void work_init(void)
+{
+  k_work_init_delayable(&server_transmission_work, server_transmission_work_fn);
+}
+
+static void lte_handler(const struct lte_lc_evt *const evt)
+{
+  switch (evt->type) {
+    case LTE_LC_EVT_NW_REG_STATUS:
+      if ((evt->nw_reg_status != LTE_LC_NW_REG_REGISTERED_HOME) &&
+          (evt->nw_reg_status != LTE_LC_NW_REG_REGISTERED_ROAMING)) {
+        break;
+      }
+
+      LOG_INF("Network registration status: %s",
+              evt->nw_reg_status == LTE_LC_NW_REG_REGISTERED_HOME ? "Connected - home network" : "Connected - roaming");
+      k_sem_give(&lte_connected);
+      break;
+    case LTE_LC_EVT_PSM_UPDATE:
+      LOG_INF("PSM parameter update: TAU: %d, Active time: %d", evt->psm_cfg.tau, evt->psm_cfg.active_time);
+      break;
+    case LTE_LC_EVT_EDRX_UPDATE: {
+      char log_buf[60];
+      ssize_t len;
+
+      len = snprintf(log_buf, sizeof(log_buf), "eDRX parameter update: eDRX: %f, PTW: %f",
+                     (double)evt->edrx_cfg.edrx, (double)evt->edrx_cfg.ptw);
+      if (len > 0) {
+        LOG_INF("%s\n", log_buf);
+      }
+      break;
+    }
+    case LTE_LC_EVT_RRC_UPDATE:
+      LOG_INF("RRC mode: %s\n", evt->rrc_mode == LTE_LC_RRC_MODE_CONNECTED ? "Connected" : "Idle");
+      break;
+    case LTE_LC_EVT_CELL_UPDATE:
+      LOG_INF("LTE cell changed: Cell ID: %d, Tracking area: %d", evt->cell.id, evt->cell.tac);
+      break;
+    default:
+      break;
+  }
+}
+
+static void modem_connect(void)
+{
+  int err = lte_lc_connect_async(lte_handler);
+  if (err) {
+    LOG_ERR("Connecting to LTE network failed, error: %d", err);
+    return;
+  }
+}
+
+static void server_disconnect(void)
+{
+  (void)close(client_fd);
+}
+
+static int server_init(void)
+{
+  struct sockaddr_in *server4 = ((struct sockaddr_in *)&host_addr);
+
+  server4->sin_family = AF_INET;
+  server4->sin_port = htons(4321);
+
+  inet_pton(AF_INET, "1.2.3.4", &server4->sin_addr);
+
+  return 0;
+}
+
+static int server_connect(void)
+{
+  int err;
+
+  client_fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (client_fd < 0) {
+    LOG_ERR("Failed to create UDP socket: %d\n", errno);
+    err = -errno;
+    goto error;
+  }
+
+  err = connect(client_fd, (struct sockaddr *)&host_addr, sizeof(struct sockaddr_in));
+  if (err < 0) {
+    LOG_ERR("Connect failed : %d\n", errno);
+    goto error;
+  }
+
+  return 0;
+
+error:
+  server_disconnect();
+  return err;
+}
+
+int main(void)
+{
+  LOG_INF("SoftSIM sample started.");
+
+  int32_t err = nrf_modem_lib_init();
+  if (err) {
+    LOG_ERR("Failed to initialize modem library, error: %d\n", err);
+  }
+
+  work_init();
+
+  modem_connect();
+
+  LOG_INF("Waiting for LTE connect event.\n");
+  do {
+  } while (k_sem_take(&lte_connected, K_SECONDS(10)));
+
+  LOG_INF("LTE connected!\n");
+  err = server_init();
+  if (err) {
+    LOG_ERR("Not able to initialize UDP server connection\n");
+    return -1;
+  }
+
+  err = server_connect();
+  if (err) {
+    LOG_ERR("Not able to connect to UDP server\n");
+    return -1;
+  }
+
+  k_work_schedule(&server_transmission_work, K_NO_WAIT);
+}

--- a/samples/softsim_static_profile/pm_static.yml
+++ b/samples/softsim_static_profile/pm_static.yml
@@ -1,3 +1,11 @@
+nvs_storage:
+  address: 0xf0000
+  size: 0x8000
+nonsecure_storage:
+  address: 0xf0000
+  span:
+  - nvs_storage
+  size: 0x8000
 tfm_its:
   address: 0xf8000
   size: 0x2000


### PR DESCRIPTION
# Overview
This PR makes two changes which I believe would be helpful to others as they cover issues and questions I ran into when testing out the SoftSIM library (at v5.1.0 with SDK v2.9.1).

## Additions
1. Add `nonsecure_storage/nvs_storage` to the static partition list. 
When using the SoftSIM library with custom boards, this can help make it explicitly clear what additional partitions are required.

3. Add a sample which demonstrates how to preserve existing profile data when re-flashing a device.
This might help in situations where during production first a test / provisioning firmware image is loaded which is later replaced by an application image. (I had a similar question as the one raised in #92.)

## Issues
Instructions for the new sample have been included in README.md in the sample folder. This is inconsistent with the existing samples which lack a README.md. 

The new sample will fault if the device is not already provisioned (a warning about this has been added to the instructions). I tried disabling `CONFIG_SOFTSIM_AUTO_INIT` and then checking the provisioning using `nrf_softsim_check_provisioned()`. This worked however, if already provisioned there seems to be some issue with calling `nrf_softsim_init()` explicitly from main, this was resulting in a fault.