### PR TITLE
chore: update nrf sdk dependency to v3.1.1

### DIFF
--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -14,7 +14,7 @@ jobs:
   build-in-docker-container:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v3.0.2
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v3.1.1
     defaults:
       run:
         # Bash shell is needed to set toolchain related environment variables in docker container

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: sdk-nrf
       path: nrf
-      revision: v3.0.2
+      revision: v3.1.1
       remote: nrfconnect
       import: true
   self:


### PR DESCRIPTION
This pull request updates the toolchain and SDK version used in the project to v3.1.1, ensuring the build environment and dependencies are aligned with the latest release.

Dependency and environment updates:

* Updated the Docker container in the GitHub Actions workflow to use `ghcr.io/nrfconnect/sdk-nrf-toolchain:v3.1.1` instead of v3.0.2, ensuring CI builds use the latest toolchain.
* Updated the `sdk-nrf` project revision in `west.yml` from v3.0.2 to v3.1.1 to match the new toolchain and incorporate the latest SDK changes.