### PR TITLE
fix: Thingy:91 X pm_static tfm_nonsecure size

### DIFF
--- a/boards/thingy91x_nrf9151_pm_static.yml
+++ b/boards/thingy91x_nrf9151_pm_static.yml
@@ -71,7 +71,7 @@ tfm:
   region: flash_primary
 tfm_nonsecure:
   address: 0x50000
-  size: 0xb0000
+  size: 0xa0000
   span: [app]
   region: flash_primary
 nonsecure_storage:


### PR DESCRIPTION
This fix is needed for NCS 3.2.0 and later.