### PR TITLE
ci: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/artifact-release.yml
+++ b/.github/workflows/artifact-release.yml
@@ -12,6 +12,9 @@ on:
         required: true
         default: '13908029974'
 
+permissions:
+  contents: write
+
 jobs:
   release-artifacts:
     runs-on: ubuntu-24.04

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -2,6 +2,9 @@ name: Check Codebase Formatting
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   clang-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -2,6 +2,9 @@ name: Lint Commit Messages
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pr_commit_checks.yml
+++ b/.github/workflows/pr_commit_checks.yml
@@ -3,6 +3,9 @@ name: PR Commit Checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pr-commit-checks:
     runs-on: ubuntu-24.04

--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Set explicit permissions blocks on all workflows missing them:
- softsim-build-using-docker: contents: read
- clang-format: contents: read
- lint-commits: contents: read
- pr_commit_checks: contents: read
- artifact-release: contents: write

Follows GitHub Actions security hardening best practices. GITHUB_TOKEN defaults to write-all without explicit permissions.