### PR TITLE
ci: SHA-pin unpinned GitHub Actions dependencies

### DIFF
--- a/.github/workflows/artifact-release.yml
+++ b/.github/workflows/artifact-release.yml
@@ -35,7 +35,7 @@ jobs:
         run: echo "artifact_name=$(echo ${{ matrix.board }} | tr "/" "_")" >> $GITHUB_OUTPUT
 
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ steps.artifact_name.outputs.artifact_name }}
           run-id: ${{ github.event.inputs.run_id }}

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -16,5 +16,5 @@ jobs:
           fetch-depth: 0
 
       - name: Linting commit messages
-        uses: wagoid/commitlint-github-action@v5
+        uses: wagoid/commitlint-github-action@9763196e10f27aef304c9b8b660d31d97fce0f99 # v5
 


### PR DESCRIPTION
Pin all remaining tag-referenced actions to immutable commit SHAs:
- wagoid/commitlint-github-action: @v5 -> @9763196e (v5)
- actions/download-artifact: @v4 -> @d3f86a10 (v4)

Tags are mutable and can be moved to point to malicious commits. SHA pinning eliminates this supply chain risk.