### PR TITLE
ci: restore renovate defaults so dependency PRs pass commitlint

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,13 +3,8 @@
   "extends": [
     "config:best-practices"
   ],
-  "ignorePresets": [
-    ":semanticPrefixFixDepsChoreOthers"
-  ],
   "timezone": "Europe/Copenhagen",
   "dependencyDashboard": true,
-  "semanticCommitType": "deps",
-  "semanticCommitScope": "",
   "rebaseWhen": "never",
   "lockFileMaintenance": {
     "enabled": true,


### PR DESCRIPTION
With those keys removed, the `config:best-practices` preset applies its default `:semanticPrefixFixDepsChoreOthers`, producing `chore(deps): ...` commits that pass commitlint.