### PR TITLE
refactor: use <errno.h> for EINVAL in ss_crypto.h

### DIFF
--- a/lib/ss_crypto.h
+++ b/lib/ss_crypto.h
@@ -3,10 +3,10 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <errno.h>
 
 #include <onomondo/softsim/log.h>
 
-#define EINVAL        22
 #define AES_BLOCKSIZE 16
 
 /**


### PR DESCRIPTION
Drop the local `#define EINVAL 22` and include <errno.h> instead. Same value, but avoids redefining a standard errno constant.