### PR TITLE
fix: abort provisioning when ss_init_fs() fails

### DIFF
--- a/lib/ss_fs.c
+++ b/lib/ss_fs.c
@@ -528,6 +528,7 @@ int port_provision(struct ss_profile *profile)
 	int rc = ss_init_fs();
 	if (rc) {
 		LOG_ERR("Failed to init FS");
+		return -1;
 	}
 
 	/* The onomondo-uicc parser hands EF contents back as hex-ASCII and stores


### PR DESCRIPTION
port_provision() logged an ss_init_fs() failure but continued, then operated on an uninitialised/empty fs_cache and an unmounted NVS instance.