### PR TITLE
fix: guard serial profile read against buffer overflow

### DIFF
--- a/samples/softsim_external_profile/CMakeLists.txt
+++ b/samples/softsim_external_profile/CMakeLists.txt
@@ -8,4 +8,4 @@ list(APPEND OVERLAY_CONFIG "$ENV{ZEPHYR_BASE}/../modules/lib/onomondo-softsim/ov
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(softsim)
 
-target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE src/main.c src/profile_serial.c)

--- a/samples/softsim_external_profile/src/main.c
+++ b/samples/softsim_external_profile/src/main.c
@@ -19,20 +19,14 @@
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/sys/reboot.h>
 
+#include "profile_serial.h"
+
 LOG_MODULE_REGISTER(softsim_sample, LOG_LEVEL_INF);
 
 /* Headroom over the full SoftSIM profile (~410 chars incl. SMSP/PIN/SMSC) */
 #define PROFILE_MAX_SIZE 512
 
-/* Semaphores */
-K_SEM_DEFINE(lte_connected, 0, 1);    /* Semaphore to signal LTE connection established */
-K_SEM_DEFINE(profile_received, 0, 1); /* Semaphore to signal profile received */
-
-struct rx_buf_t {
-	char *buf;
-	size_t len;
-	size_t pos;
-};
+K_SEM_DEFINE(lte_connected, 0, 1); /* Semaphore to signal LTE connection established */
 
 static int client_fd;
 static struct sockaddr_storage host_addr;
@@ -160,30 +154,6 @@ static void drain_logs_and_reboot(void)
 		k_yield();
 	}
 	sys_reboot(0);
-}
-
-void serial_cb(const struct device *dev, void *user_data)
-{
-	int rx_recv = 0;
-	struct rx_buf_t *rx = (struct rx_buf_t *)user_data;
-	char *rx_buf = rx->buf;
-	size_t *rx_buf_pos = &rx->pos;
-
-	if (!uart_irq_update(uart_dev)) {
-		return;
-	}
-
-	while (uart_irq_rx_ready(uart_dev)) {
-		rx_recv = uart_fifo_read(uart_dev, &rx_buf[*rx_buf_pos], 1);
-
-		if ((rx_buf[*rx_buf_pos] == '\n') || (rx_buf[*rx_buf_pos] == '\r')) {
-			rx_buf[*rx_buf_pos] = 0;
-			k_sem_give(&profile_received);
-			return;
-		}
-
-		*rx_buf_pos += rx_recv;
-	}
 }
 
 static int provision_softsim_from_serial(void)

--- a/samples/softsim_external_profile/src/profile_serial.c
+++ b/samples/softsim_external_profile/src/profile_serial.c
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+#include "profile_serial.h"
+
+#include <zephyr/drivers/uart.h>
+
+K_SEM_DEFINE(profile_received, 0, 1);
+
+void serial_cb(const struct device *dev, void *user_data)
+{
+	int rx_recv = 0;
+	struct rx_buf_t *rx = (struct rx_buf_t *)user_data;
+	char *rx_buf = rx->buf;
+	size_t *rx_buf_pos = &rx->pos;
+
+	if (!uart_irq_update(dev)) {
+		return;
+	}
+
+	while (uart_irq_rx_ready(dev)) {
+		rx_recv = uart_fifo_read(dev, &rx_buf[*rx_buf_pos], 1);
+
+		if ((rx_buf[*rx_buf_pos] == '\n') || (rx_buf[*rx_buf_pos] == '\r')) {
+			rx_buf[*rx_buf_pos] = 0;
+			k_sem_give(&profile_received);
+			return;
+		}
+
+		*rx_buf_pos += rx_recv;
+	}
+}

--- a/samples/softsim_external_profile/src/profile_serial.c
+++ b/samples/softsim_external_profile/src/profile_serial.c
@@ -11,24 +11,29 @@ K_SEM_DEFINE(profile_received, 0, 1);
 
 void serial_cb(const struct device *dev, void *user_data)
 {
-	int rx_recv = 0;
 	struct rx_buf_t *rx = (struct rx_buf_t *)user_data;
 	char *rx_buf = rx->buf;
 	size_t *rx_buf_pos = &rx->pos;
+	uint8_t c;
 
 	if (!uart_irq_update(dev)) {
 		return;
 	}
 
-	while (uart_irq_rx_ready(dev)) {
-		rx_recv = uart_fifo_read(dev, &rx_buf[*rx_buf_pos], 1);
-
-		if ((rx_buf[*rx_buf_pos] == '\n') || (rx_buf[*rx_buf_pos] == '\r')) {
+	/* Read before deciding what to do with the byte: uart_fifo_read() is what
+	 * acknowledges the RX interrupt, so returning with a byte still pending would
+	 * re-enter this ISR immediately and starve the thread waiting on the profile. */
+	while (uart_fifo_read(dev, &c, 1) == 1) {
+		/* Stop on the terminator, or once the buffer is full -- keeping room for
+		 * the NUL -- rather than overflowing it. Mask RX before signalling so the
+		 * buffer cannot be mutated while main() reads it. */
+		if ((c == '\n') || (c == '\r') || (*rx_buf_pos == rx->len - 1)) {
 			rx_buf[*rx_buf_pos] = 0;
+			uart_irq_rx_disable(dev);
 			k_sem_give(&profile_received);
 			return;
 		}
 
-		*rx_buf_pos += rx_recv;
+		rx_buf[(*rx_buf_pos)++] = c;
 	}
 }

--- a/samples/softsim_external_profile/src/profile_serial.h
+++ b/samples/softsim_external_profile/src/profile_serial.h
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+#ifndef PROFILE_SERIAL_H
+#define PROFILE_SERIAL_H
+
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+
+/* Receive buffer handed to serial_cb() as user data. */
+struct rx_buf_t {
+	char *buf;
+	size_t len;
+	size_t pos;
+};
+
+/* Given by serial_cb() once the profile string in the buffer is terminated. */
+extern struct k_sem profile_received;
+
+void serial_cb(const struct device *dev, void *user_data);
+
+#endif /* PROFILE_SERIAL_H */


### PR DESCRIPTION
serial_cb wrote each received byte into the fixed PROFILE_MAX_SIZE buffer without checking the position, so a profile longer than the buffer would overflow it. Stop at the buffer limit (reserving the NUL terminator) and signal what was received instead.