### PR TITLE
fix: size profile RX buffer for a full onomondo-uicc profile

### DIFF
--- a/samples/softsim_external_profile/src/main.c
+++ b/samples/softsim_external_profile/src/main.c
@@ -13,7 +13,8 @@
 
 LOG_MODULE_REGISTER(softsim_sample, LOG_LEVEL_INF);
 
-#define PROFILE_MAX_SIZE 360 /* Maximum size of a Onomondo SoftSIM profile */
+/* Headroom over the full SoftSIM profile (~410 chars incl. SMSP/PIN/SMSC) */
+#define PROFILE_MAX_SIZE 512
 
 /* Semaphores */
 K_SEM_DEFINE(lte_connected, 0, 1);    /* Semaphore to signal LTE connection established */


### PR DESCRIPTION
PROFILE_MAX_SIZE was 360, below the ~410 hex chars a full onomondo-uicc profile (SMSP + PIN/PUK + SMSC) can reach. Bump to 512 so the serial buffer isn't the limiting factor.