### PR TITLE
fix: free the old buffer when ss_fputc grows it

### DIFF
--- a/lib/ss_fs.c
+++ b/lib/ss_fs.c
@@ -401,6 +401,7 @@ int ss_fputc(int c, ss_FILE fp)
 		}
 
 		memcpy(entry->buf, old_buffer, old_size);
+		SS_FREE(old_buffer);
 		entry->_b_size += 20;
 	}
 


### PR DESCRIPTION
When ss_fputc needs a larger cache buffer it allocates a new one and copies
the old contents over, but never freed the old allocation, leaking it on every growth. ss_fputc isn't used in practice, but lets cover this anyway.