### PR TITLE
chore: add spdx headers for SBOM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 Onomondo ApS
+# SPDX-License-Identifier: GPL-3.0-only
+
 add_subdirectory_ifdef(CONFIG_SOFTSIM lib)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023-2026 Onomondo ApS
+# SPDX-License-Identifier: GPL-3.0-only
+
 zephyr_library()
 
 # onomondo-uicc submodule integration.

--- a/lib/build_asserts.c
+++ b/lib/build_asserts.c
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #include <zephyr/kernel.h>
 #include <autoconf.h>
 

--- a/lib/include/nrf_softsim.h
+++ b/lib/include/nrf_softsim.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #ifndef _NRF_SOFTSIM_H
 #define _NRF_SOFTSIM_H
 

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #include <autoconf.h>
 
 #include <zephyr/init.h>

--- a/lib/ss_cache.c
+++ b/lib/ss_cache.c
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #include <string.h>
 
 #include <zephyr/sys/printk.h>

--- a/lib/ss_cache.h
+++ b/lib/ss_cache.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #ifndef _F_CACHE_H_
 #define _F_CACHE_H_
 

--- a/lib/ss_crypto.c
+++ b/lib/ss_crypto.c
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>

--- a/lib/ss_crypto.h
+++ b/lib/ss_crypto.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #ifndef SS_CRYPTO_H
 #define SS_CRYPTO_H
 

--- a/lib/ss_fs.c
+++ b/lib/ss_fs.c
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #include <stdlib.h>
 
 #include <zephyr/fs/nvs.h>

--- a/lib/ss_heap.c
+++ b/lib/ss_heap.c
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #include <zephyr/kernel.h>
 
 #include <onomondo/softsim/mem.h>

--- a/lib/ss_logp_zephyr.c
+++ b/lib/ss_logp_zephyr.c
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/samples/softsim_external_profile/CMakeLists.txt
+++ b/samples/softsim_external_profile/CMakeLists.txt
@@ -1,8 +1,5 @@
-#
-# Copyright (c) 2020 Nordic Semiconductor
-#
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
-#
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 Onomondo ApS
+# SPDX-License-Identifier: GPL-3.0-only
 
 cmake_minimum_required(VERSION 3.20.0)
 

--- a/samples/softsim_external_profile/src/main.c
+++ b/samples/softsim_external_profile/src/main.c
@@ -1,3 +1,8 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2023-2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
 #include <stdio.h>
 
 #include <nrf_softsim.h>

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2023 Onomondo ApS
+# SPDX-License-Identifier: GPL-3.0-only
+
 if(CMAKE_OBJCOPY)
   set(ONOMONDO_SOFTSIM_OBJCOPY ${CMAKE_OBJCOPY})
 else()


### PR DESCRIPTION
Adds standardized copyright and license headers to the project's source and configuration files. Ensuring legal clarity and compliance throughout the codebase for ease of SBOM generation.