### PR TITLE
fix: guard against negative nvs_read return in ss_init_fs

### DIFF
--- a/lib/ss_fs.c
+++ b/lib/ss_fs.c
@@ -109,6 +109,13 @@ int ss_init_fs(void)
 	}
 
 	rc = nvs_read(&fs, DIR_ID, NULL, 0);
+	if (rc < 0) {
+		/* No DIR entry yet (e.g. -ENOENT before provisioning) or an NVS
+		 * error. Don't assign a negative rc to the size_t len. Treat it
+		 * like an empty DIR blob (the existing rc == 0 path). */
+		LOG_WRN("No DIR entry in NVS (%d); starting with empty filesystem cache", rc);
+		rc = 0;
+	}
 	len = rc;
 
 	/* Read DIR_ENTRY from NVS


### PR DESCRIPTION
ss_init_fs() assigned the nvs_read() result directly to the size_t len without checking for a negative errno return. When the DIR entry is absent (nvs_read returns -ENOENT) or NVS errors, the negative rc wraps to a huge size_t, which then drives a bogus SS_ALLOC_N() and an assert/over-read over a buffer that was never validly sized.

Clamp a negative rc to 0 so the no-entry case is handled like an empty DIR blob (the existing rc == 0 path): no allocation, empty filesystem cache.