### PR TITLE
chore: update nRF Connect SDK dependency to v3.4.0

### DIFF
--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -17,7 +17,7 @@ jobs:
   build-in-docker-container:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v3.2.2
+    container: ghcr.io/nrfconnect/sdk-nrf-toolchain:v3.4.0
     defaults:
       run:
         # Bash shell is needed to set toolchain related environment variables in docker container

--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,7 @@ manifest:
   projects:
     - name: sdk-nrf
       path: nrf
-      revision: v3.2.2
+      revision: v3.4.0
       remote: nrfconnect
       import: true
       submodules: true


### PR DESCRIPTION
Bump the sdk-nrf west revision and the CI toolchain container from v3.2.2 to v3.4.0.

This PR needs these merged into `master` first (v3.4.0 removes/reorg's these APIs, so this won't build alone):

- [x] #152 — PSA MAC abort fix
- [x] #151 — drop `psa_open_key` (key-use paths) *(stacked on #152)*
- [x] #153 — key-existence check without a handle
- [x] #157 — drop `psa_open_key` (`setup_key_helper`)
- [x] #155 — enable Partition Manager (deprecated default in 3.4)
- [x] #156 — POSIX socket headers (Zephyr 4.4)

Then rebase this branch and confirm all 5 boards build green. (This PR's builds stay red until then.)
