### PR TITLE
fix: enable Partition Manager explicitly for the sample

### DIFF
--- a/samples/softsim_external_profile/sysbuild.conf
+++ b/samples/softsim_external_profile/sysbuild.conf
@@ -1,1 +1,6 @@
+# Partition Manager is deprecated and no longer enabled by default from NCS 3.4.
+# SoftSIM still relies on it (pm_static.yml layouts, NVS storage placement, and
+# the bundled template.hex address in ../../sysbuild/CMakeLists.txt), so opt in.
+SB_CONFIG_PARTITION_MANAGER=y
+
 SB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX=y


### PR DESCRIPTION
Partition Manager is deprecated and no longer enabled by default from NCS 3.4. SoftSIM still relies on it (pm_static.yml layouts, NVS storage placement, and the bundled template.hex base address in sysbuild/CMakeLists.txt), so set SB_CONFIG_PARTITION_MANAGER=y.