### PR TITLE
fix: include POSIX socket headers in the external-profile sample

### DIFF
--- a/samples/softsim_external_profile/src/main.c
+++ b/samples/softsim_external_profile/src/main.c
@@ -4,6 +4,9 @@
  */
 
 #include <stdio.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
 
 #include <nrf_softsim.h>
 #include <modem/lte_lc.h>


### PR DESCRIPTION
The Zephyr POSIX API rework no longer exposes the BSD socket names (socket/connect/send/close/inet_pton) via <zephyr/net/socket.h>. Include <unistd.h>, <sys/socket.h> and <arpa/inet.h> explicitly, matching the NCS cellular samples.