### PR TITLE
fix: unblock NCS v3.4.0 integration (sysbuild, nrf_softsim_init, auto-init overlay)

### DIFF
--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -74,25 +74,16 @@ jobs:
           west build --sysbuild --pristine=always --board ${{ matrix.board }} \
             -- -DEXTRA_CONF_FILE=overlay-static.conf
 
-      # This module's sysbuild hook runs for every sysbuild build in the workspace,
-      # so it must not require the (deprecated, default-off) Partition Manager.
-      # hello_world is the cheapest application that exercises the hook.
+      # The sysbuild hook runs for every sysbuild build in the workspace; hello_world
+      # proves it works without the (deprecated, default-off) Partition Manager.
       - name: Build an unrelated sample without Partition Manager
         if: matrix.board == 'nrf9151dk/nrf9151/ns'
         run: |
           west build --sysbuild --pristine=always --board ${{ matrix.board }} \
             -d build-hello zephyr/samples/hello_world
 
-      # Manual init: proves nrf_softsim_init() is defined and linkable, and that
-      # the sample's manual bring-up path compiles.
-      #
-      # The grep guards the other half. overlay-softsim.conf must not set
-      # CONFIG_SOFTSIM_AUTO_INIT: it is applied after the application's prj.conf,
-      # so setting it there silently overrides an application that opts out --
-      # while changing nothing otherwise, since Kconfig already defaults it to y.
-      # A build cannot catch that regression from here: EXTRA_CONF_FILE is applied
-      # after the module overlay and would win, and only a prj.conf opt-out
-      # reproduces it -- which is not the sample's default mode.
+      # Proves nrf_softsim_init() links. The grep keeps CONFIG_SOFTSIM_AUTO_INIT out
+      # of overlay-softsim.conf, where it would override an application's opt-out.
       - name: Build firmware (manual init mode)
         if: matrix.board == 'nrf9151dk/nrf9151/ns'
         working-directory: modules/lib/onomondo-softsim/samples/softsim_external_profile

--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -73,3 +73,32 @@ jobs:
         run: |
           west build --sysbuild --pristine=always --board ${{ matrix.board }} \
             -- -DEXTRA_CONF_FILE=overlay-static.conf
+
+      # This module's sysbuild hook runs for every sysbuild build in the workspace,
+      # so it must not require the (deprecated, default-off) Partition Manager.
+      # hello_world is the cheapest application that exercises the hook.
+      - name: Build an unrelated sample without Partition Manager
+        if: matrix.board == 'nrf9151dk/nrf9151/ns'
+        run: |
+          west build --sysbuild --pristine=always --board ${{ matrix.board }} \
+            -d build-hello zephyr/samples/hello_world
+
+      # Manual init: proves nrf_softsim_init() is defined and linkable, and that
+      # the sample's manual bring-up path compiles.
+      #
+      # The grep guards the other half. overlay-softsim.conf must not set
+      # CONFIG_SOFTSIM_AUTO_INIT: it is applied after the application's prj.conf,
+      # so setting it there silently overrides an application that opts out --
+      # while changing nothing otherwise, since Kconfig already defaults it to y.
+      # A build cannot catch that regression from here: EXTRA_CONF_FILE is applied
+      # after the module overlay and would win, and only a prj.conf opt-out
+      # reproduces it -- which is not the sample's default mode.
+      - name: Build firmware (manual init mode)
+        if: matrix.board == 'nrf9151dk/nrf9151/ns'
+        working-directory: modules/lib/onomondo-softsim/samples/softsim_external_profile
+        run: |
+          west build --sysbuild --pristine=always --board ${{ matrix.board }} \
+            -- -DEXTRA_CONF_FILE=overlay-manual-init.conf
+          grep -qx '# CONFIG_SOFTSIM_AUTO_INIT is not set' \
+            build/softsim_external_profile/zephyr/.config
+          ! grep -q '^CONFIG_SOFTSIM_AUTO_INIT' ../../overlay-softsim.conf

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Either let the kernel bring SoftSIM up on boot with `CONFIG_SOFTSIM_AUTO_INIT=y`
 1. Call `nrf_softsim_init()` before any other SoftSIM API — `nrf_softsim_provision()` and `nrf_softsim_check_provisioned()` need the filesystem it initializes. With auto-init this happened from `SYS_INIT` at `APPLICATION` level, before `main()`.
 2. Send `AT%CSUS=2` yourself after `nrf_modem_lib_init()`.
 
-Manual init is what runtime SIM selection needs: bring SoftSIM up and send `AT%CSUS=2` only when a profile is actually provisioned, so a device without one falls back to a physical SIM without a separate firmware build.
+Manual init is what runtime SIM selection needs: bring SoftSIM up and send `AT%CSUS=2` only when a profile is actually provisioned, so a device without one falls back to a physical SIM without a separate firmware build. The sample builds in this mode with `-DEXTRA_CONF_FILE=overlay-manual-init.conf`.
 
 SoftSIM entrypoint starts its own work queue and returns immediately after. The handler installed with `nrf_modem_softsim_req_handler_set()` will enqueue requests, as they come and the work queue will unblock and handle the request. The SoftSIM context will be blocked most of the time. The main interaction happens on boot.
 

--- a/README.md
+++ b/README.md
@@ -409,7 +409,12 @@ The inital DIR is designed to prioritize most accessed files as well. Internally
 
 
 #### SoftSIM integration in application code
-Either call `nrf_softsim_init()` explicitly or let the kernel do it on boot with the config option.
+Either let the kernel bring SoftSIM up on boot with `CONFIG_SOFTSIM_AUTO_INIT=y` (the default), or set it to `n` and call `nrf_softsim_init()` explicitly. The two are not quite equivalent: with auto-init the module also selects the software SIM from an `NRF_MODEM_LIB_ON_INIT` hook, and that hook is compiled out along with the rest. Taking the manual route, the application owns both halves:
+
+1. Call `nrf_softsim_init()` before any other SoftSIM API — `nrf_softsim_provision()` and `nrf_softsim_check_provisioned()` need the filesystem it initializes. With auto-init this happened from `SYS_INIT` at `APPLICATION` level, before `main()`.
+2. Send `AT%CSUS=2` yourself after `nrf_modem_lib_init()`.
+
+Manual init is what runtime SIM selection needs: bring SoftSIM up and send `AT%CSUS=2` only when a profile is actually provisioned, so a device without one falls back to a physical SIM without a separate firmware build.
 
 SoftSIM entrypoint starts its own work queue and returns immediately after. The handler installed with `nrf_modem_softsim_req_handler_set()` will enqueue requests, as they come and the work queue will unblock and handle the request. The SoftSIM context will be blocked most of the time. The main interaction happens on boot.
 

--- a/lib/include/nrf_softsim.h
+++ b/lib/include/nrf_softsim.h
@@ -15,11 +15,18 @@ struct ss_profile;
 /**
  * @brief Initialize the SoftSIM library and install handlers
  *
- * Only use if CONFIG_NRF_SOFTSIM_AUTO_INIT is not set.
+ * Brings up the SoftSIM filesystem, installs the modem request handler and
+ * starts the SoftSIM work queue.
  *
- * This function initializes the SoftSIM module by calling the Onomondo
- * initialization function. It sets up the necessary context and prepares
- * the SoftSIM for use.
+ * With CONFIG_SOFTSIM_AUTO_INIT=y (the default) this runs from SYS_INIT at
+ * APPLICATION level, before main(), and the modem is told to use the software
+ * SIM from an NRF_MODEM_LIB_ON_INIT hook. Call this function only when that
+ * option is disabled, and then the application owns both halves:
+ *
+ *   1. Call it before any other SoftSIM API -- nrf_softsim_provision() and
+ *      nrf_softsim_check_provisioned() need the filesystem it initializes.
+ *   2. Select the software SIM itself with AT%CSUS=2 after nrf_modem_lib_init(),
+ *      because the hook that normally does so is compiled out.
  *
  * @return 0 on success
  */

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -63,7 +63,7 @@ struct softsim_req_node {
 /**
  * @brief Initialize the Onomondo SoftSIM.
  */
-int onomondo_init(void)
+int nrf_softsim_init(void)
 {
 	/* Init the filesystem here?
 	 * Pro: pretty smooth :) -> no need to init and deinit more than needed..
@@ -327,7 +327,7 @@ void nrf_modem_softsim_req_handler(enum nrf_modem_softsim_cmd req, uint16_t req_
 }
 
 #ifdef CONFIG_SOFTSIM_AUTO_INIT
-SYS_INIT(onomondo_init, APPLICATION, 0);
+SYS_INIT(nrf_softsim_init, APPLICATION, 0);
 
 static void ss_on_modem_lib_init(int ret, void *ctx)
 {

--- a/overlay-softsim.conf
+++ b/overlay-softsim.conf
@@ -1,6 +1,10 @@
 # Onomondo SoftSIM Configurations
+#
+# CONFIG_SOFTSIM_AUTO_INIT is deliberately not set here. It already defaults to
+# y in Kconfig, so setting it would change nothing for the default case -- but
+# this overlay is applied after the application's prj.conf, so it would silently
+# override an application that opts out of auto-init.
 CONFIG_SOFTSIM=y
-CONFIG_SOFTSIM_AUTO_INIT=y
 
 # Log subsystem on; SoftSIM Kconfig sets sensible defaults
 CONFIG_LOG=y

--- a/overlay-softsim.conf
+++ b/overlay-softsim.conf
@@ -1,9 +1,6 @@
 # Onomondo SoftSIM Configurations
-#
-# CONFIG_SOFTSIM_AUTO_INIT is deliberately not set here. It already defaults to
-# y in Kconfig, so setting it would change nothing for the default case -- but
-# this overlay is applied after the application's prj.conf, so it would silently
-# override an application that opts out of auto-init.
+# Don't set CONFIG_SOFTSIM_AUTO_INIT here; it would override an application's
+# prj.conf opt-out of auto-init (CI-enforced).
 CONFIG_SOFTSIM=y
 
 # Log subsystem on; SoftSIM Kconfig sets sensible defaults

--- a/samples/softsim_external_profile/overlay-manual-init.conf
+++ b/samples/softsim_external_profile/overlay-manual-init.conf
@@ -1,0 +1,4 @@
+# Manual init mode overlay: the application brings SoftSIM up itself instead of
+# the module's SYS_INIT, which is what runtime SIM selection needs.
+# Build with: west build --sysbuild -b <board> -- -DEXTRA_CONF_FILE=overlay-manual-init.conf
+CONFIG_SOFTSIM_AUTO_INIT=n

--- a/samples/softsim_external_profile/src/main.c
+++ b/samples/softsim_external_profile/src/main.c
@@ -11,6 +11,7 @@
 #include <nrf_softsim.h>
 #include <modem/lte_lc.h>
 #include <modem/nrf_modem_lib.h>
+#include <nrf_modem_at.h>
 #include <zephyr/kernel.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/device.h>
@@ -207,6 +208,16 @@ int main(void)
 {
 	LOG_INF("SoftSIM sample started.");
 
+#ifndef CONFIG_SOFTSIM_AUTO_INIT
+	/* Without auto-init the module's SYS_INIT is compiled out, so bring SoftSIM
+	 * up here -- before nrf_softsim_check_provisioned(), which needs the
+	 * filesystem this initializes. */
+	if (nrf_softsim_init()) {
+		LOG_ERR("Failed to initialize SoftSIM.");
+		return -1;
+	}
+#endif
+
 	if (!nrf_softsim_check_provisioned()) {
 		if (provision_softsim_from_serial() != 0) {
 			return -1;
@@ -217,6 +228,16 @@ int main(void)
 	if (err) {
 		LOG_ERR("Failed to initialize modem library, error: %d", err);
 	}
+
+#ifndef CONFIG_SOFTSIM_AUTO_INIT
+	/* The module's NRF_MODEM_LIB_ON_INIT hook is compiled out too, so select the
+	 * software SIM here. Runtime SIM selection lives at this point: send this
+	 * only when a profile is provisioned, and the device falls back to a
+	 * physical SIM otherwise. */
+	if (nrf_modem_at_printf("AT%%CSUS=2")) {
+		LOG_ERR("Failed to select software SIM.");
+	}
+#endif
 
 #ifdef CONFIG_SOFTSIM_FACTORY_RESET_ON_PROVISION
 	/* Modem is now initialised; if a profile was just provisioned (static or

--- a/sysbuild/CMakeLists.txt
+++ b/sysbuild/CMakeLists.txt
@@ -1,45 +1,65 @@
 # SPDX-FileCopyrightText: Copyright (c) 2023 Onomondo ApS
 # SPDX-License-Identifier: GPL-3.0-only
 
-if(CMAKE_OBJCOPY)
-  set(ONOMONDO_SOFTSIM_OBJCOPY ${CMAKE_OBJCOPY})
-else()
-  find_program(ONOMONDO_SOFTSIM_OBJCOPY
-    NAMES arm-zephyr-eabi-objcopy arm-none-eabi-objcopy objcopy
-    REQUIRED
-  )
-endif()
+# This file is a Zephyr module sysbuild hook: it is evaluated for *every*
+# sysbuild build in a workspace whose manifest includes this repo, not just for
+# SoftSIM applications. Everything below needs the Partition Manager to compute
+# the nvs_storage address, and PM is deprecated and no longer enabled by default
+# from NCS 3.4 -- so it must all stay behind the SB_CONFIG_PARTITION_MANAGER
+# guard. Without it, referencing the (nonexistent) partition_manager target
+# fails the configure step of unrelated applications.
+if(SB_CONFIG_PARTITION_MANAGER)
+  if(CMAKE_OBJCOPY)
+    set(ONOMONDO_SOFTSIM_OBJCOPY ${CMAKE_OBJCOPY})
+  else()
+    find_program(ONOMONDO_SOFTSIM_OBJCOPY
+      NAMES arm-zephyr-eabi-objcopy arm-none-eabi-objcopy objcopy
+      REQUIRED
+    )
+  endif()
 
-set(ONOMONDO_SOFTSIM_BASE_ADDRESS $<TARGET_PROPERTY:partition_manager,PM_NVS_STORAGE_ADDRESS>)
-set(ONOMONDO_SOFTSIM_TEMPLATE_OUTPUT ${CMAKE_BINARY_DIR}/onomondo-softsim/template.hex)
+  set(ONOMONDO_SOFTSIM_BASE_ADDRESS $<TARGET_PROPERTY:partition_manager,PM_NVS_STORAGE_ADDRESS>)
+  set(ONOMONDO_SOFTSIM_TEMPLATE_OUTPUT ${CMAKE_BINARY_DIR}/onomondo-softsim/template.hex)
 
-add_custom_command(
-  OUTPUT template.hex
-  COMMAND ${ONOMONDO_SOFTSIM_OBJCOPY}
-  --input-target=binary
-  --output-target=ihex
-  --change-address ${ONOMONDO_SOFTSIM_BASE_ADDRESS}
-  ${CMAKE_CURRENT_LIST_DIR}/../lib/profile/template.bin
-  ${ONOMONDO_SOFTSIM_TEMPLATE_OUTPUT}
-  BYPRODUCTS ${ONOMONDO_SOFTSIM_TEMPLATE_OUTPUT} # This is needed for Ninja
-)
-add_custom_target(onomondo_softsim_template DEPENDS template.hex)
-
-if(SB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX)
-  set_property(
-    GLOBAL PROPERTY
-    nvs_storage_PM_HEX_FILE
+  add_custom_command(
+    OUTPUT template.hex
+    COMMAND ${ONOMONDO_SOFTSIM_OBJCOPY}
+    --input-target=binary
+    --output-target=ihex
+    --change-address ${ONOMONDO_SOFTSIM_BASE_ADDRESS}
+    ${CMAKE_CURRENT_LIST_DIR}/../lib/profile/template.bin
     ${ONOMONDO_SOFTSIM_TEMPLATE_OUTPUT}
+    BYPRODUCTS ${ONOMONDO_SOFTSIM_TEMPLATE_OUTPUT} # This is needed for Ninja
   )
+  add_custom_target(onomondo_softsim_template DEPENDS template.hex)
 
-  set_property(
-    GLOBAL PROPERTY
-    nvs_storage_PM_TARGET
-    onomondo_softsim_template
+  if(SB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX)
+    set_property(
+      GLOBAL PROPERTY
+      nvs_storage_PM_HEX_FILE
+      ${ONOMONDO_SOFTSIM_TEMPLATE_OUTPUT}
+    )
+
+    set_property(
+      GLOBAL PROPERTY
+      nvs_storage_PM_TARGET
+      onomondo_softsim_template
+    )
+  endif()
+elseif(SB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX)
+  message(FATAL_ERROR
+    "SB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX requires SB_CONFIG_PARTITION_MANAGER=y: "
+    "the template profile is placed at the address the Partition Manager assigns to "
+    "the nvs_storage partition. Add SB_CONFIG_PARTITION_MANAGER=y to sysbuild.conf, "
+    "or drop SB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX and flash the template separately."
   )
 endif()
 
 function(${SYSBUILD_CURRENT_MODULE_NAME}_pre_cmake)
+  if(NOT SB_CONFIG_PARTITION_MANAGER)
+    return()
+  endif()
+
   # Set the default NCS static partition layout for the Thingy:91
   if(SB_CONFIG_THINGY91_STATIC_PARTITIONS_FACTORY)
     set(PM_STATIC_YML_FILE ${SYSBUILD_SOFTSIM_MODULE_DIR}/boards/thingy91_pm_static.yml CACHE INTERNAL "")


### PR DESCRIPTION
Three independent bugs found integrating SoftSIM on NCS v3.4.0, in decreasing order of impact.

**`sysbuild/CMakeLists.txt` broke every sysbuild build in the workspace.** It is a Zephyr module sysbuild hook, evaluated for every sysbuild build in a workspace whose manifest includes this repo — including unrelated NCS samples — and it referenced the `partition_manager` target unconditionally. Partition Manager is deprecated and no longer enabled by default from NCS 3.4, so those builds failed with `Target "partition_manager" not found`. Guarded on `SB_CONFIG_PARTITION_MANAGER`, with a clear error when `SB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX` is set without it. Guarding on PM rather than on the bundle option keeps the `onomondo_softsim_template` target available for PM builds that do not bundle, which is the manual flash workflow in the README. The runtime never needed PM — `ss_fs.c` uses the devicetree `FIXED_PARTITION_*` APIs.

**`nrf_softsim_init()` was declared and documented but never defined** — only `onomondo_init()`, referenced solely by the `SYS_INIT`. Any application taking the documented route failed to link. Renamed the definition to match the header rather than adding a second entry point; the old name was in no header and referenced nowhere else. Also documents what auto-init does that the manual path does not: `AT%CSUS=2` is sent from an `NRF_MODEM_LIB_ON_INIT` hook inside the same ifdef, so the two are not equivalent, and `nrf_softsim_init()` must be called before any other SoftSIM API because it is what initializes the filesystem.

**`overlay-softsim.conf` set `CONFIG_SOFTSIM_AUTO_INIT=y`.** Kconfig already defaults it to y, so it changed nothing for the default case — but the overlay is applied after the application's `prj.conf`, so it silently overrode applications opting out, which then hit `multiple definition of nrf_modem_hook_sim_select_hook`. Dropped. This unblocks runtime SIM selection: bring SoftSIM up and send `AT%CSUS=2` only when a profile is provisioned, so a device without one falls back to a physical SIM without a separate firmware build.

CI gains two builds: `hello_world` with the module present but SoftSIM disabled, and the sample in manual-init mode.

Fixes #169. Reported by @hallard.
