### PR TITLE
ci: build applications other than the SoftSIM sample

### DIFF
--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -84,3 +84,38 @@ jobs:
           west build --sysbuild --pristine=always --board ${{ matrix.board }} \
             -- -DSB_CONFIG_PARTITION_MANAGER=y
           test -f build/merged.hex
+
+      # Every step above builds our own sample, which wires SoftSIM in through
+      # its CMakeLists.txt, sysbuild.conf and boards/<board>.overlay. These two
+      # cover the README's integration path instead: SoftSIM added to somebody
+      # else's application. at_client is a small NCS sample that uses the modem
+      # library and builds without a bootloader, which is what
+      # nrf91_softsim_partitions.dtsi is written for.
+      #
+      # DTC_OVERLAY_FILE, not EXTRA_DTC_OVERLAY_FILE: at_client carries its own
+      # partition layout and the two cannot stack, so ours has to replace the
+      # application's overlay list rather than append to it.
+      - name: Build a foreign application with SoftSIM
+        if: matrix.board == 'nrf9151dk/nrf9151/ns'
+        env:
+          SOFTSIM: modules/lib/onomondo-softsim
+        run: |
+          west build --sysbuild --pristine=always --board ${{ matrix.board }} \
+            -d build-at-client nrf/samples/cellular/at_client \
+            -- -DOVERLAY_CONFIG="$PWD/$SOFTSIM/overlay-softsim.conf" \
+               -DDTC_OVERLAY_FILE="$PWD/$SOFTSIM/dts/softsim/nrf91_softsim_partitions.dtsi;$PWD/$SOFTSIM/dts/softsim/nrf91_softsim_sram.dtsi"
+          grep -qx 'CONFIG_SOFTSIM=y' build-at-client/at_client/zephyr/.config
+
+      # Same, bundling the template: an integrator has to be able to produce a
+      # flashable artifact for their own application, not just for our sample.
+      - name: Build a foreign application with SoftSIM (bundled template)
+        if: matrix.board == 'nrf9151dk/nrf9151/ns'
+        env:
+          SOFTSIM: modules/lib/onomondo-softsim
+        run: |
+          west build --sysbuild --pristine=always --board ${{ matrix.board }} \
+            -d build-at-client-bundled nrf/samples/cellular/at_client \
+            -- -DOVERLAY_CONFIG="$PWD/$SOFTSIM/overlay-softsim.conf" \
+               -DDTC_OVERLAY_FILE="$PWD/$SOFTSIM/dts/softsim/nrf91_softsim_partitions.dtsi;$PWD/$SOFTSIM/dts/softsim/nrf91_softsim_sram.dtsi" \
+               -DSB_CONFIG_SOFTSIM_BUNDLE_TEMPLATE_HEX=y
+          test -f build-at-client-bundled/merged.hex


### PR DESCRIPTION
Based on #167, since the steps need the `dts/softsim/*.dtsi` layouts it introduces.

**Landing this after #167 merges:** rebase `ci/foreign-app-builds` onto `master` and force-push, *then* retarget this PR. Retargeting on its own is not enough — #167 is squash merged, so its commits never appear on master and this PR would re-propose the whole devicetree branch as its own diff. For the same reason, don't delete `feat/dts` until this PR has been retargeted.

Every build step so far uses `samples/softsim_external_profile`, which wires SoftSIM in through its own `CMakeLists.txt`, `sysbuild.conf` and `boards/<board>.overlay`. That leaves the README's integration path — SoftSIM added to an existing application through `overlay-softsim.conf` — untested, and it is the path integrators actually take. It is also how the three bugs in #169 were found.

Adds two builds of `nrf/samples/cellular/at_client` with SoftSIM, with and without the template bundled. at_client is a small NCS sample that uses the modem library and builds without a bootloader, which is what `nrf91_softsim_partitions.dtsi` is written for. One board (`nrf9151dk/nrf9151/ns`) is enough — the delta is board-independent — so the other four legs are unaffected.

Both steps use `DTC_OVERLAY_FILE` rather than `EXTRA_DTC_OVERLAY_FILE`: at_client carries its own partition layout and two complete layouts cannot stack, so the SoftSIM layout has to replace the application's overlay list. This is the gotcha #167 now documents in the README.

Between them these reach two things no existing step does: the sysbuild hook's `else()` branch with SoftSIM enabled, and the module's own `CMakeLists.txt` in an application that is not ours.

Verified locally on nrf9151dk/nrf9151/ns, NCS v3.4.0 — at_client builds at 152212 B, and the bundled variant produces `merged.hex` with the template at the `nvs_storage` address (0xF0000). Both steps also pass in CI on this PR.
