### PR TITLE
ci: bump onomondo-uicc only on release tags

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,6 +45,13 @@
         "pinDigest"
       ],
       "minimumReleaseAge": null
+    },
+    {
+      "description": "onomondo-uicc is pinned to a release tag via the .gitmodules branch field, so only accept refs shaped like a release. The git-refs datasource returns branches and tags in one list, so without this a tag-like branch name could move the pin to an unreleased HEAD.",
+      "matchManagers": [
+        "git-submodules"
+      ],
+      "allowedVersions": "/^v\\d+\\.\\d+\\.\\d+$/"
     }
   ]
 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lib/onomondo-uicc"]
 	path = lib/onomondo-uicc
 	url = https://github.com/onomondo/onomondo-uicc
+	branch = v2.2.1


### PR DESCRIPTION
Records the tag as the submodule branch so Renovate bumps on a new onomondo-uicc release instead of tracking master HEAD. No pin change: already at v2.2.1.

Note `git submodule update --remote` no longer works; use `--init --recursive`.