### PR TITLE
fix: honor SOFTSIM_UICC_*=n in the uicc option wiring

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -30,8 +30,10 @@ function(_softsim_default_bool opt default doc)
   endif()
 endfunction()
 
+# Zephyr only exports set Kconfig bools to CMake, so inside a Zephyr build
+# (CONFIG_SOFTSIM guards this directory) an undefined symbol means =n.
 function(_softsim_set_uicc_bool uicc_opt softsim_opt default doc)
-  if(DEFINED ${softsim_opt})
+  if(DEFINED ${softsim_opt} OR DEFINED CONFIG_SOFTSIM)
     if("${${softsim_opt}}" STREQUAL "y")
       set(${uicc_opt} ON CACHE BOOL "${doc}" FORCE)
     else()


### PR DESCRIPTION
Setting any `CONFIG_SOFTSIM_UICC_*=n` was silently ignored: Zephyr exports only *set* Kconfig bools to CMake, so `=n` left the symbol undefined and `_softsim_set_uicc_bool()` fell back to the option's ON default.

Fix: inside a Zephyr build (`CONFIG_SOFTSIM` is always defined there), treat an undefined symbol as `=n`. Standalone CMake builds keep the old defaulting.

Note: with the currently pinned onomondo-uicc, `USE_LOGS=n` now correctly drops `-DCONFIG_USE_LOGS` from the core compile, but the image doesn't shrink until a core update decouples `SS_LOGP` from `NDEBUG`.

Verified:
- `-DCONFIG_USE_LOGS` in `compile_commands.json`: 43 with defaults, 0 with `=n`.
- Default-config app image byte-identical to master (the fix only changes the previously-dead `=n` path).
- Twister native_sim ASan/LSan: 6/6 suites, 64/64 cases.
