### PR TITLE
fix: make REFRESH tracking and SMS reassembly sizing tunable

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -113,6 +113,27 @@ config SOFTSIM_UICC_BUILD_LIB_ONLY
     bool "Build libraries only in onomondo-uicc"
     default y
 
+config SOFTSIM_UICC_FS_CHG_MAX_FILES
+    int "Files budgeted in the REFRESH changed-file list"
+    default 20
+    range 1 65535
+    help
+        Sizes the buffer recording which files remote management changed, so
+        the next REFRESH can name them to the modem. Costs 10 bytes per file
+        and exists twice per SIM session. On overflow the change is logged
+        and left out of the REFRESH file list. Upstream defaults to 100; 20
+        comfortably covers the shipped file tree's real paths.
+
+config SOFTSIM_UICC_SMS_RX_MAX_PARTS
+    int "Concatenated-SMS parts accepted for reassembly"
+    default 5
+    range 1 255
+    help
+        Incoming concatenated SMS claiming more parts than this are refused
+        instead of buffered. Each part costs heap while reassembly is in
+        flight; OTA remote-management commands fit well within 5 parts.
+        Upstream defaults to 255, the TS 23.040 maximum.
+
 endmenu
 
 endif #SOFTSIM

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -94,6 +94,22 @@ foreach(_t IN LISTS _softsim_libs)
   target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${_t})
 endforeach()
 
+# Port sizing for the SIM core. SS_FS_CHG_PATH_MAXLEN=10 is the deepest
+# standard path (MF/DF/DF/EF plus terminator, TS 102 223 clause 8.18); the
+# shipped file tree needs 8. The counts come from Kconfig (defaults in a
+# non-Zephyr consumer's build).
+if(NOT DEFINED CONFIG_SOFTSIM_UICC_FS_CHG_MAX_FILES)
+  set(CONFIG_SOFTSIM_UICC_FS_CHG_MAX_FILES 20)
+endif()
+if(NOT DEFINED CONFIG_SOFTSIM_UICC_SMS_RX_MAX_PARTS)
+  set(CONFIG_SOFTSIM_UICC_SMS_RX_MAX_PARTS 5)
+endif()
+target_compile_definitions(uicc PRIVATE
+  SS_FS_CHG_PATH_MAXLEN=10
+  SS_FS_CHG_MAX_FILES=${CONFIG_SOFTSIM_UICC_FS_CHG_MAX_FILES}
+  SS_SMS_RX_MAX_PARTS=${CONFIG_SOFTSIM_UICC_SMS_RX_MAX_PARTS}
+)
+
 zephyr_include_directories(include)
 zephyr_include_directories(onomondo-uicc/include)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -96,14 +96,7 @@ endforeach()
 
 # Port sizing for the SIM core. SS_FS_CHG_PATH_MAXLEN=10 is the deepest
 # standard path (MF/DF/DF/EF plus terminator, TS 102 223 clause 8.18); the
-# shipped file tree needs 8. The counts come from Kconfig (defaults in a
-# non-Zephyr consumer's build).
-if(NOT DEFINED CONFIG_SOFTSIM_UICC_FS_CHG_MAX_FILES)
-  set(CONFIG_SOFTSIM_UICC_FS_CHG_MAX_FILES 20)
-endif()
-if(NOT DEFINED CONFIG_SOFTSIM_UICC_SMS_RX_MAX_PARTS)
-  set(CONFIG_SOFTSIM_UICC_SMS_RX_MAX_PARTS 5)
-endif()
+# shipped file tree needs 8. The counts come from Kconfig.
 target_compile_definitions(uicc PRIVATE
   SS_FS_CHG_PATH_MAXLEN=10
   SS_FS_CHG_MAX_FILES=${CONFIG_SOFTSIM_UICC_FS_CHG_MAX_FILES}
@@ -123,12 +116,5 @@ zephyr_library_sources(
   ss_logp_zephyr.c
   build_asserts.c
 )
-
-# ss_profile.c is compiled here, outside the submodule's scope, so it needs the
-# logging switch passed explicitly or its SS_LOGP diagnostics compile out.
-if(CONFIG_USE_LOGS)
-  set_source_files_properties(onomondo-uicc/utils/ss_profile.c
-    PROPERTIES COMPILE_DEFINITIONS CONFIG_USE_LOGS)
-endif()
 
 target_compile_definitions(${ZEPHYR_CURRENT_LIBRARY} PRIVATE CONFIG_CUSTOM_HEAP)

--- a/tests/apdu/CMakeLists.txt
+++ b/tests/apdu/CMakeLists.txt
@@ -31,6 +31,14 @@ foreach(_t uicc storage milenage crypto)
     $<TARGET_PROPERTY:zephyr_interface,INTERFACE_COMPILE_OPTIONS>)
 endforeach()
 
+# Same port sizing lib/CMakeLists.txt applies for firmware (Kconfig defaults),
+# so the suite exercises the core as shipped.
+target_compile_definitions(uicc PRIVATE
+  SS_FS_CHG_PATH_MAXLEN=10
+  SS_FS_CHG_MAX_FILES=20
+  SS_SMS_RX_MAX_PARTS=5
+)
+
 # The nRF port of the UICC filesystem underneath the core, on the real Zephyr
 # NVS over the flash simulator -- the integration this suite exists to pin.
 target_sources(app PRIVATE


### PR DESCRIPTION
The SIM core budgets its REFRESH file list and SMS reassembly for far more than this port ever uses, costing ~4 KB of heap.
Size both to fit, overridable via Kconfig.
