### PR TITLE
fix: express FS_READ_ONLY in the post-shift flags space

### DIFF
--- a/lib/ss_cache.h
+++ b/lib/ss_cache.h
@@ -9,8 +9,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define FS_READ_ONLY       (1UL << 8)
-#define FS_COMMIT_ON_CLOSE (1UL << 7) /* Commit changes to NVS on close */
+/* Flag masks for ss_dir_entry.flags, i.e. the HIGH byte of the DIR id
+ * ((id & 0xFF00) >> 8): a mask here must fit uint8_t. FS_READ_ONLY
+ * corresponds to raw-id bit 8. */
+#define FS_READ_ONLY       (1U << 0) /* Never commit to NVS on close */
+#define FS_COMMIT_ON_CLOSE (1U << 7) /* Commit changes to NVS on close */
 
 /* How many files may hold a content buffer at once. */
 #define SS_MAX_ENTRIES 10

--- a/lib/ss_cache.h
+++ b/lib/ss_cache.h
@@ -11,7 +11,11 @@
 
 /* Flag masks for ss_dir_entry.flags, i.e. the HIGH byte of the DIR id
  * ((id & 0xFF00) >> 8): a mask here must fit uint8_t. FS_READ_ONLY
- * corresponds to raw-id bit 8. */
+ * corresponds to raw-id bit 8.
+ * The id doubles as the NVS key, so a key's high byte IS its flag byte: bit 8
+ * set marks the file read-only, and 0x81xx silently disables a close-commit.
+ * The template generator must keep plain files out of the flagged ranges
+ * (pinned by tests/apdu's read-only tripwire). */
 #define FS_READ_ONLY       (1U << 0) /* Never commit to NVS on close */
 #define FS_COMMIT_ON_CLOSE (1U << 7) /* Commit changes to NVS on close */
 

--- a/tests/apdu/src/main.c
+++ b/tests/apdu/src/main.c
@@ -20,12 +20,16 @@
 
 #include <zephyr/drivers/flash.h>
 #include <zephyr/kernel.h>
+#include <zephyr/kvss/nvs.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/storage/flash_map.h>
 #include <zephyr/ztest.h>
 
 #include <nrf_softsim.h>
+#include <onomondo/softsim/mem.h>
 #include <onomondo/softsim/softsim.h>
+
+#include "ss_cache.h"
 
 /* ss_fs.c does LOG_MODULE_DECLARE(softsim, ...); register it once here.
  * (The UICC core logs through its own softsim_uicc module.) */
@@ -284,4 +288,49 @@ ZTEST(softsim_apdu, test_authenticate_rejects_a_forged_mac)
 	len = transact(authenticate, sizeof(authenticate), rsp);
 	expect_sw(rsp, len, 0x9862, "AUTHENTICATE with a forged MAC");
 	zassert_equal(len, 2, "a rejected AUTHENTICATE must carry no response data");
+}
+
+/*
+ * DIR ids carry their flags in the high byte, and FS_READ_ONLY is live since
+ * its repair -- a template key allocated in 0x01xx would silently make that
+ * file read-only, its writes never committing on close. The template
+ * generator lives outside this repository, so the invariant is pinned on the
+ * artifact it ships: no file in template.bin may decode as read-only. The
+ * commit-on-close count proves the walk saw real flag bytes rather than a
+ * vacuously empty decode. The table build also refuses two paths that share a
+ * hash, so a negative return pins the shipped template collision-free.
+ */
+ZTEST(softsim_apdu, test_template_marks_no_file_read_only)
+{
+	static uint8_t blob[2048];
+	struct nvs_fs dir_fs = {
+		.flash_device = PARTITION_DEVICE(nvs_storage),
+		.sector_size = 0x1000,
+		.sector_count = PARTITION_SIZE(nvs_storage) / 0x1000,
+		.offset = PARTITION_OFFSET(nvs_storage),
+	};
+	struct ss_dir_entry *dir;
+	size_t commit_on_close = 0;
+	ssize_t len;
+
+	zassert_ok(nvs_mount(&dir_fs), "could not mount the seeded partition");
+	len = nvs_read(&dir_fs, 1, blob, sizeof(blob)); /* DIR_ID in ss_fs.c */
+	zassert_true(len > 0 && len <= (ssize_t)sizeof(blob), "DIR blob read failed (%d)",
+		     (int)len);
+
+	int n = ss_dir_table_from_blob(blob, (size_t)len, &dir);
+
+	zassert_true(n > 0,
+		     "the template DIR did not decode (%d): empty, or two paths share a hash", n);
+
+	for (int i = 0; i < n; i++) {
+		zassert_false(dir[i].flags & FS_READ_ONLY,
+			      "entry %d (key 0x%04x) decodes as read-only", i, dir[i].key);
+		if (dir[i].flags & FS_COMMIT_ON_CLOSE) {
+			commit_on_close++;
+		}
+	}
+	zassert_true(commit_on_close > 0, "no COMMIT_ON_CLOSE file: flag decoding is broken");
+
+	SS_FREE(dir);
 }

--- a/tests/cache/src/main.c
+++ b/tests/cache/src/main.c
@@ -162,21 +162,15 @@ ZTEST(softsim_cache, test_flags_are_derived_but_key_keeps_all_16_bits)
 }
 
 /*
- * Known defect: flags is a uint8_t holding (id >> 8), so a flag macro above
- * 0xFF can never match. FS_COMMIT_ON_CLOSE (1<<7) is expressed in post-shift
- * space and works; FS_READ_ONLY (1<<8) is expressed in raw-id space and does
- * not, which makes the read-only guard in ss_fs.c dead code.
- *
- * Expected to fail until the units mismatch is fixed. Fixing it changes no
- * behaviour today -- the shipped template marks no file read-only -- but the
- * fix must not touch key derivation (see the test above).
+ * flags is a uint8_t holding (id >> 8), so every flag macro must be expressed
+ * in that post-shift space or it can never match. FS_READ_ONLY was once
+ * (1<<8) in raw-id space, which made the read-only guard in ss_fs.c dead code.
  */
 ZTEST(softsim_cache, test_flag_macros_fit_the_flags_field)
 {
 	zassert_true(FS_COMMIT_ON_CLOSE <= UINT8_MAX, "FS_COMMIT_ON_CLOSE cannot match");
 	zassert_true(FS_READ_ONLY <= UINT8_MAX, "FS_READ_ONLY cannot match a uint8_t flags");
 }
-ZTEST_EXPECT_FAIL(softsim_cache, test_flag_macros_fit_the_flags_field);
 
 /*
  * Lookups compare path hashes, so two paths hashing identically would silently

--- a/tests/fs/src/main.c
+++ b/tests/fs/src/main.c
@@ -59,6 +59,8 @@ int port_check_provisioned(void);
  * that asserts an exact on-flash length needs a record nothing else touches. */
 #define PATCH_ID    0x8011
 #define PATCH_PATH  "/3f00/a101"
+#define RO_ID       0x8102 /* high byte 0x81 -> FS_READ_ONLY | FS_COMMIT_ON_CLOSE */
+#define RO_PATH     "/3f00/r000"
 
 /* Records with no flag byte at all: ss_fclose() does not commit these, so a
  * write to one stays dirty in the cache. That makes them the only way to reach
@@ -83,6 +85,7 @@ int port_check_provisioned(void);
 #define A004_PROV_PATH  "/3f00/a004"
 
 static const uint8_t plain_content[] = {0x98, 0x00, 0x10, 0x32, 0x54, 0x76, 0x98, 0x10, 0x32, 0x14};
+static const uint8_t ro_content[] = {0x0a, 0x1b, 0x2c, 0x3d, 0x4e, 0x5f, 0x60, 0x71};
 static const uint8_t commit_content[] = {1, 2, 3, 4, 5, 6, 7, 8};
 static const uint8_t patch_content[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
 static const uint8_t deinit_content[] = {0xd0, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7};
@@ -162,6 +165,7 @@ static void seed_nvs(void)
 	len = put_record(blob, 0, PLAIN_ID, PLAIN_PATH);
 	len = put_record(blob, len, COMMIT_ID, COMMIT_PATH);
 	len = put_record(blob, len, PATCH_ID, PATCH_PATH);
+	len = put_record(blob, len, RO_ID, RO_PATH);
 	len = put_record(blob, len, DEINIT_ID, DEINIT_PATH);
 	len = put_record(blob, len, GROW_ID, GROW_PATH);
 	len = put_record(blob, len, IMSI_PROV_ID, IMSI_PROV_PATH);
@@ -183,6 +187,8 @@ static void seed_nvs(void)
 		     "seeding %s failed", COMMIT_PATH);
 	zassume_true(nvs_write(&seed, PATCH_ID, patch_content, sizeof(patch_content)) > 0,
 		     "seeding %s failed", PATCH_PATH);
+	zassume_true(nvs_write(&seed, RO_ID, ro_content, sizeof(ro_content)) > 0,
+		     "seeding %s failed", RO_PATH);
 	zassume_true(nvs_write(&seed, DEINIT_ID, deinit_content, sizeof(deinit_content)) > 0,
 		     "seeding %s failed", DEINIT_PATH);
 	zassume_true(nvs_write(&seed, GROW_ID, commit_content, sizeof(commit_content)) > 0,
@@ -273,6 +279,31 @@ ZTEST(softsim_fs, test_write_then_reread_in_the_same_session)
 	zassert_mem_equal(buf + sizeof(patch), patch_content + sizeof(patch),
 			  sizeof(patch_content) - sizeof(patch),
 			  "the bytes past the write were not preserved on flash");
+}
+
+/*
+ * FS_READ_ONLY must win over FS_COMMIT_ON_CLOSE: a record carrying both flags
+ * must never be committed by ss_fclose(). That is the only close behaviour the
+ * flag changes -- without FS_COMMIT_ON_CLOSE the close never wrote anyway --
+ * and it is the footgun a template key straying into 0x81xx would arm: the
+ * file's close-commit silently stops. The shipped template marks no file
+ * read-only, so this is the guard's only caller. Only the close path is
+ * pinned: the eviction write-back and the ss_deinit_fs() flush still commit a
+ * dirty read-only buffer -- pre-existing behaviour, deliberately not asserted.
+ */
+ZTEST(softsim_fs, test_read_only_file_is_not_committed_on_close)
+{
+	const uint8_t marker = 0x99;
+	uint8_t buf[sizeof(ro_content)];
+	ss_FILE f = ss_fopen(RO_PATH, "r+");
+
+	zassert_not_null(f, "%s did not open", RO_PATH);
+	zassert_equal(ss_fwrite(&marker, 1, 1, f), 1, "%s did not take the write", RO_PATH);
+	ss_fclose(f);
+
+	zassert_equal(read_flash_record(RO_ID, buf, sizeof(buf)), sizeof(ro_content),
+		      "the close changed the record length on flash");
+	zassert_equal(buf[0], ro_content[0], "a read-only record reached flash on close");
 }
 
 /*


### PR DESCRIPTION
Stacked on #197, which already makes the cache cap real. FS_READ_ONLY was defined in raw-id space where it could never match the uint8_t flags field, leaving the read-only close guard dead. Adds a tripwire over the shipped template: no file decodes read-only, at least one commits on close, and no two paths share a hash.