### PR TITLE
feat: make the memory footprint tunable and lower defaults to measured floors

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -145,12 +145,14 @@ endmenu
 # CONFIG_SOFTSIM — same reason the log-level symbols below live here.
 config SOFTSIM_STACK_SIZE
     int "SoftSIM work-queue thread stack size"
-    default 10000
+    default 6000
     help
         Stack size of the dedicated work-queue thread that runs all SoftSIM
         processing (ATR, APDU transactions, filesystem and crypto). The
-        default is deliberately generous; measure the high-water mark with
-        CONFIG_THREAD_ANALYZER before lowering it in a product build.
+        default keeps ~2.7x the high-water mark measured on an nRF9151-DK
+        (2200 bytes across provisioning, LTE attach and 12 re-attach cycles
+        with debug logs on); measure with CONFIG_THREAD_ANALYZER before
+        lowering it further in a product build.
 
 # Conditional defaults for per-layer log levels — placed BEFORE each template
 # source so they win over the template's `default LOG_DEFAULT_LEVEL` fallback
@@ -180,8 +182,11 @@ if SOFTSIM
 config MAIN_STACK_SIZE
     default 5000
 
+# Measured on an nRF9151-DK: 17856-byte peak across provisioning, LTE attach
+# and 12 re-attach cycles, plus headroom for a worst-case OTA response
+# allocation (~4.1 KB) and margin. lib/build_asserts.c enforces the floor.
 config HEAP_MEM_POOL_SIZE
-    default 30000
+    default 24000
 
 config LOG_DEFAULT_LEVEL
     default 1

--- a/Kconfig
+++ b/Kconfig
@@ -184,8 +184,12 @@ config MAIN_STACK_SIZE
 
 # Measured on an nRF9151-DK: 17856-byte peak across provisioning, LTE attach
 # and 12 re-attach cycles, plus headroom for a worst-case OTA response
-# allocation (~4.1 KB) and margin. lib/build_asserts.c enforces the floor.
-config HEAP_MEM_POOL_SIZE
+# allocation (~4.1 KB) and margin. Declared as a heap contribution so the
+# kernel rounds the effective pool up to it without overriding an
+# application's own CONFIG_HEAP_MEM_POOL_SIZE (which stays in charge when
+# larger). lib/build_asserts.c enforces the floor on the effective size.
+config HEAP_MEM_POOL_ADD_SIZE_SOFTSIM
+    int "Heap memory pool contribution of SoftSIM"
     default 24000
 
 config LOG_DEFAULT_LEVEL

--- a/Kconfig
+++ b/Kconfig
@@ -140,6 +140,18 @@ endif #SOFTSIM
 
 endmenu
 
+# Top-level (not under `if SOFTSIM`) so autoconf defines it in every build,
+# including the native_sim unit-test builds that compile nrf_softsim.c without
+# CONFIG_SOFTSIM — same reason the log-level symbols below live here.
+config SOFTSIM_STACK_SIZE
+    int "SoftSIM work-queue thread stack size"
+    default 10000
+    help
+        Stack size of the dedicated work-queue thread that runs all SoftSIM
+        processing (ATR, APDU transactions, filesystem and crypto). The
+        default is deliberately generous; measure the high-water mark with
+        CONFIG_THREAD_ANALYZER before lowering it in a product build.
+
 # Conditional defaults for per-layer log levels — placed BEFORE each template
 # source so they win over the template's `default LOG_DEFAULT_LEVEL` fallback
 # (Kconfig: first matching default wins).
@@ -161,6 +173,15 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 # bumps them; otherwise the production-friendly sizing applies. These are
 # `default` directives so any explicit value in a prj.conf or overlay wins.
 if SOFTSIM
+
+# Stack/heap sizing SoftSIM needs on top of Zephyr's defaults. Previously hard
+# assignments in overlay-softsim.conf, which an application prj.conf could not
+# lower; as `default` directives any explicit value wins.
+config MAIN_STACK_SIZE
+    default 5000
+
+config HEAP_MEM_POOL_SIZE
+    default 30000
 
 config LOG_DEFAULT_LEVEL
     default 1

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -1,0 +1,75 @@
+# Memory
+
+What the SoftSIM costs in RAM and flash on an nRF91, which knobs size it, and the
+system-level budgets around it. Numbers marked *measured* come from a pristine build of
+[`samples/softsim_external_profile`](../samples/softsim_external_profile) for
+`nrf9151dk/nrf9151/ns` on NCS v3.4.0; re-measure on your own configuration before
+trimming anything.
+
+## The budget
+
+The nRF9151 has 256 KB of SRAM, split three ways before the application sees any of it:
+
+| Region | Size | Owner |
+|---|---|---|
+| TF-M secure RAM | 48 KB | Set by [`overlay-softsim.conf`](../overlay-softsim.conf) (`CONFIG_PM_PARTITION_SIZE_TFM_SRAM=0xC000`) — already trimmed from the 88 KB NCS default for nRF91. TF-M uses ~40 KB of it (*measured*). |
+| Modem shared memory | 17.4 KB | `nrf_modem_lib` control (1,256 B) + TX (8,320 B) + RX (8,192 B) heaps, NCS defaults. RX has a hard floor of 2,616 B on this SoC; TX can go down to 1,024 B if your application's traffic allows. Trace is off. |
+| Application | 190.6 KB | Everything else, including this module. |
+
+The sample uses **~73.5 KB** of the application region at defaults (*measured*), of which
+the SoftSIM module itself accounts for roughly 15 KB of static RAM plus its share of the
+system heap (below). Flash is not a constraint: the sample image is ~148 KB of the 864 KB
+application partition, of which the SIM core and glue are ~65 KB.
+
+## Where SoftSIM RAM goes
+
+Static:
+
+| Item | Size | Knob |
+|---|---|---|
+| Work-queue thread stack | 10,000 B | `CONFIG_SOFTSIM_STACK_SIZE`. Deliberately generous; measure before lowering (see below). |
+| Log-formatting buffers in the SIM core | 5,125 B | Compiled in unconditionally by the vendored SIM-core revision; once the submodule updates past its logging rework, `CONFIG_SOFTSIM_UICC_USE_LOGS=n` removes them along with ~25 KB of flash-resident log strings. |
+| Work queue object, FIFO, filesystem bookkeeping | ~450 B | — |
+
+Heap, drawn from the Zephyr system heap (`CONFIG_HEAP_MEM_POOL_SIZE`, default 30,000 B —
+a build assert enforces the floor because every SIM operation allocates from it):
+
+| Item | Size | When |
+|---|---|---|
+| Filesystem directory table | ~6.3 KB | From `ss_init_fs()` until deinit: one entry + name per file (≈100 files in a provisioned profile). |
+| SIM context | ~4.9 KB | Allocated on the modem's first `INIT` request, freed on `DEINIT` (kept while suspended). |
+| File-content cache | ≤ ~2.5 KB | Up to 10 file buffers, recycled least-used-first. |
+| Selected-path state, FCP/access decodes | 1.5–3 KB | Per selected file; freed on reselect. |
+| APDU transactions | ~1.1 KB | Two live command/response pairs; three during a `6Cxx`/`61xx` retry. |
+| OTA (remote file management) response | 4.1 KB | Peak, per OTA command. |
+
+Steady state lands around 15–18 KB of the 30 KB pool; the headroom exists for OTA peaks
+and fragmentation.
+
+## Sizing knobs
+
+- `CONFIG_SOFTSIM_STACK_SIZE` — the dedicated thread that runs all SIM processing.
+- `CONFIG_MAIN_STACK_SIZE` (default 5000) and `CONFIG_HEAP_MEM_POOL_SIZE` (default
+  30000) — SoftSIM raises these via Kconfig defaults, so an application `prj.conf` can
+  override them. The main-stack demand comes from the provisioning path, which builds
+  the decoded profile (~1 KB of locals) on the caller's stack.
+- `CONFIG_SOFTSIM_NRF_DEBUG_LOGS` / `CONFIG_SOFTSIM_LIBS_DEBUG_LOGS` (default off) —
+  each enables verbose logging and grows the deferred log buffer to 5,000 / 16,384 B
+  plus ~1.5 KB of UART buffers. Never in production.
+- The NVS partition is fixed at 32 KB and build-asserted: the provisioned filesystem
+  occupies ~8 KB (2 of the 8 flash sectors); the rest is wear-leveling and
+  garbage-collection headroom for a flash area that takes writes on every
+  authentication. Do not shrink it.
+
+To measure before trimming: build with `CONFIG_THREAD_ANALYZER=y` (+`CONFIG_INIT_STACKS=y`)
+for per-thread stack high-water marks and `CONFIG_SYS_HEAP_RUNTIME_STATS=y` for
+`sys_heap_runtime_stats_get()` on the system heap, then exercise boot → provisioning →
+LTE attach → several authentications before reading the numbers.
+
+## Around the module
+
+Costs in the sample that are not SoftSIM's, worth knowing when you budget an application:
+the AT host library (`CONFIG_AT_HOST_LIBRARY`) statically allocates a 4 KB command buffer
+plus a 1 KB thread — it exists for interactive convenience and can be dropped. The system
+heap also serves POSIX/socket plumbing (~800 B of configured add-sizes), and the modem
+library keeps its own 1 KB heap for API calls.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -16,7 +16,7 @@ The nRF9151 has 256 KB of SRAM, split three ways before the application sees any
 | Modem shared memory | 17.4 KB | `nrf_modem_lib` control (1,256 B) + TX (8,320 B) + RX (8,192 B) heaps, NCS defaults. RX has a hard floor of 2,616 B on this SoC; TX can go down to 1,024 B if your application's traffic allows. Trace is off. |
 | Application | 190.6 KB | Everything else, including this module. |
 
-The sample uses **~73.5 KB** of the application region at defaults (*measured*), of which
+The sample uses **~63.5 KB** of the application region at defaults (*measured*), of which
 the SoftSIM module itself accounts for roughly 15 KB of static RAM plus its share of the
 system heap (below). Flash is not a constraint: the sample image is ~148 KB of the 864 KB
 application partition, of which the SIM core and glue are ~65 KB.
@@ -27,11 +27,11 @@ Static:
 
 | Item | Size | Knob |
 |---|---|---|
-| Work-queue thread stack | 10,000 B | `CONFIG_SOFTSIM_STACK_SIZE`. Deliberately generous; measure before lowering (see below). |
+| Work-queue thread stack | 6,000 B | `CONFIG_SOFTSIM_STACK_SIZE`. High-water mark *measured* at 2,200 B across provisioning, attach and 12 re-attach cycles with debug logs on; the default keeps ~2.7x that for OTA/SMS paths the measurement did not exercise. |
 | Log-formatting buffers in the SIM core | 5,125 B | Compiled in unconditionally by the vendored SIM-core revision; once the submodule updates past its logging rework, `CONFIG_SOFTSIM_UICC_USE_LOGS=n` removes them along with ~25 KB of flash-resident log strings. |
 | Work queue object, FIFO, filesystem bookkeeping | ~450 B | — |
 
-Heap, drawn from the Zephyr system heap (`CONFIG_HEAP_MEM_POOL_SIZE`, default 30,000 B —
+Heap, drawn from the Zephyr system heap (`CONFIG_HEAP_MEM_POOL_SIZE`, default 24,000 B —
 a build assert enforces the floor because every SIM operation allocates from it):
 
 | Item | Size | When |
@@ -43,14 +43,15 @@ a build assert enforces the floor because every SIM operation allocates from it)
 | APDU transactions | ~1.1 KB | Two live command/response pairs; three during a `6Cxx`/`61xx` retry. |
 | OTA (remote file management) response | 4.1 KB | Peak, per OTA command. |
 
-Steady state lands around 15–18 KB of the 30 KB pool; the headroom exists for OTA peaks
-and fragmentation.
+Steady state lands around 15–16 KB; the *measured* peak is 17,856 B across provisioning,
+LTE attach and 12 re-attach cycles. The 24 KB default keeps that peak plus a worst-case
+OTA response and margin for fragmentation.
 
 ## Sizing knobs
 
 - `CONFIG_SOFTSIM_STACK_SIZE` — the dedicated thread that runs all SIM processing.
 - `CONFIG_MAIN_STACK_SIZE` (default 5000) and `CONFIG_HEAP_MEM_POOL_SIZE` (default
-  30000) — SoftSIM raises these via Kconfig defaults, so an application `prj.conf` can
+  24000) — SoftSIM raises these via Kconfig defaults, so an application `prj.conf` can
   override them. The main-stack demand comes from the provisioning path, which builds
   the decoded profile (~1 KB of locals) on the caller's stack.
 - `CONFIG_SOFTSIM_NRF_DEBUG_LOGS` / `CONFIG_SOFTSIM_LIBS_DEBUG_LOGS` (default off) —

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -12,7 +12,7 @@ The nRF9151 has 256 KB of SRAM, split three ways before the application sees any
 
 | Region | Size | Owner |
 |---|---|---|
-| TF-M secure RAM | 48 KB | Set by [`overlay-softsim.conf`](../overlay-softsim.conf) (`CONFIG_PM_PARTITION_SIZE_TFM_SRAM=0xC000`) — already trimmed from the 88 KB NCS default for nRF91. TF-M uses ~40 KB of it (*measured*). |
+| TF-M secure RAM | 48 KB | Fixed in [`dts/softsim/nrf91_softsim_sram.dtsi`](../dts/softsim/nrf91_softsim_sram.dtsi) — already trimmed from the 88 KB NCS default for nRF91; `CONFIG_PM_PARTITION_SIZE_TFM_SRAM` no longer affects the split. TF-M itself uses ~40 KB (*measured*), and the reservation deliberately stays at 48 KB: the next SPU-granularity step down (8 KB) would leave ~1.2 KB of slack, and this TF-M instance also serves your application's own PSA keys, ITS data and crypto. Don't trim it. |
 | Modem shared memory | 17.4 KB | `nrf_modem_lib` control (1,256 B) + TX (8,320 B) + RX (8,192 B) heaps, NCS defaults. RX has a hard floor of 2,616 B on this SoC; TX can go down to 1,024 B if your application's traffic allows. Trace is off. |
 | Application | 190.6 KB | Everything else, including this module. |
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -31,8 +31,11 @@ Static:
 | Log-formatting buffers in the SIM core | 5,125 B | Compiled in unconditionally by the vendored SIM-core revision; once the submodule updates past its logging rework, `CONFIG_SOFTSIM_UICC_USE_LOGS=n` removes them along with ~25 KB of flash-resident log strings. |
 | Work queue object, FIFO, filesystem bookkeeping | ~450 B | — |
 
-Heap, drawn from the Zephyr system heap (`CONFIG_HEAP_MEM_POOL_SIZE`, default 24,000 B —
-a build assert enforces the floor because every SIM operation allocates from it):
+Heap, drawn from the Zephyr system heap. SoftSIM contributes
+`CONFIG_HEAP_MEM_POOL_ADD_SIZE_SOFTSIM` (default 24,000 B), so the kernel rounds the
+effective pool up to that even when the application sets a smaller
+`CONFIG_HEAP_MEM_POOL_SIZE`; a build assert enforces the floor on the effective size
+because every SIM operation allocates from it:
 
 | Item | Size | When |
 |---|---|---|
@@ -50,10 +53,13 @@ OTA response and margin for fragmentation.
 ## Sizing knobs
 
 - `CONFIG_SOFTSIM_STACK_SIZE` — the dedicated thread that runs all SIM processing.
-- `CONFIG_MAIN_STACK_SIZE` (default 5000) and `CONFIG_HEAP_MEM_POOL_SIZE` (default
-  24000) — SoftSIM raises these via Kconfig defaults, so an application `prj.conf` can
-  override them. The main-stack demand comes from the provisioning path, which builds
-  the decoded profile (~1 KB of locals) on the caller's stack.
+- `CONFIG_MAIN_STACK_SIZE` (default 5000) — raised via a Kconfig default, so an
+  application `prj.conf` can override it. The demand comes from the provisioning path,
+  which builds the decoded profile (~1 KB of locals) on the caller's stack.
+- `CONFIG_HEAP_MEM_POOL_ADD_SIZE_SOFTSIM` (default 24000) — SoftSIM's system-heap
+  contribution. Applications keep their own `CONFIG_HEAP_MEM_POOL_SIZE`; the effective
+  pool is the larger of that and the summed contributions. Lower the contribution only
+  with a measured heap profile.
 - `CONFIG_SOFTSIM_NRF_DEBUG_LOGS` / `CONFIG_SOFTSIM_LIBS_DEBUG_LOGS` (default off) —
   each enables verbose logging and grows the deferred log buffer to 5,000 / 16,384 B
   plus ~1.5 KB of UART buffers. Never in production.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -43,6 +43,12 @@ function(_softsim_set_uicc_bool uicc_opt softsim_opt default doc)
   endif()
 endfunction()
 
+# Longest path in a provisioned profile is 20 chars; the submodule default
+# (100) mostly pays in the many stack frames sized SS_STORAGE_PATH_MAX+1 in
+# the storage layer. Must match the value the port sources compile with, see
+# zephyr_library_compile_definitions below.
+set(CONFIG_SS_STORAGE_PATH_MAX "32" CACHE STRING "Maximum path length for storage operations")
+
 message(STATUS "SoftSIM: Building static libraries from onomondo-uicc")
 message(STATUS "SoftSIM: onomondo-uicc library install dir: ${_softsim_install_dir}")
 file(MAKE_DIRECTORY ${_softsim_install_dir})
@@ -118,3 +124,6 @@ zephyr_library_sources(
 )
 
 target_compile_definitions(${ZEPHYR_CURRENT_LIBRARY} PRIVATE CONFIG_CUSTOM_HEAP)
+# Keep the port's storage_path[] and path buffers the same size as the
+# submodule's (the header falls back to 100 when the define is absent).
+target_compile_definitions(${ZEPHYR_CURRENT_LIBRARY} PRIVATE SS_STORAGE_PATH_MAX=${CONFIG_SS_STORAGE_PATH_MAX})

--- a/lib/build_asserts.c
+++ b/lib/build_asserts.c
@@ -18,7 +18,10 @@
 BUILD_ASSERT(2 * KEY_SIZE <= A001_LEN, "SoftSIM: A001 layout changed");
 BUILD_ASSERT(A004_HEADER_SIZE + 2 * KEY_SIZE <= A004_LEN, "SoftSIM: A004 layout changed");
 
-BUILD_ASSERT(CONFIG_HEAP_MEM_POOL_SIZE >= EXPECTED_MIN_HEAP_SIZE,
+/* K_HEAP_MEM_POOL_SIZE is the effective pool: the application's
+ * CONFIG_HEAP_MEM_POOL_SIZE rounded up to the sum of all
+ * HEAP_MEM_POOL_ADD_SIZE_* contributions (ours included). */
+BUILD_ASSERT(K_HEAP_MEM_POOL_SIZE >= EXPECTED_MIN_HEAP_SIZE,
 	     "SoftSIM: "
 	     "Heap memory pool size is not valid. "
 	     "Please reconfigure the project.");

--- a/lib/build_asserts.c
+++ b/lib/build_asserts.c
@@ -10,7 +10,7 @@
 #include <onomondo/utils/ss_profile.h>
 
 #define EXPECTED_PARTITION_SIZE 0x8000
-#define EXPECTED_MIN_HEAP_SIZE  30000
+#define EXPECTED_MIN_HEAP_SIZE  24000
 
 /* nrf_softsim_provision() validates the parsed profile by indexing the KI/OPc pair in
  * A001 and the KIC/KID pair in A004. Pin those layouts so a submodule bump that moves

--- a/lib/build_asserts.c
+++ b/lib/build_asserts.c
@@ -21,10 +21,9 @@ BUILD_ASSERT(A004_HEADER_SIZE + 2 * KEY_SIZE <= A004_LEN, "SoftSIM: A004 layout 
 /* K_HEAP_MEM_POOL_SIZE is the effective pool: the application's
  * CONFIG_HEAP_MEM_POOL_SIZE rounded up to the sum of all
  * HEAP_MEM_POOL_ADD_SIZE_* contributions (ours included). */
-BUILD_ASSERT(K_HEAP_MEM_POOL_SIZE >= EXPECTED_MIN_HEAP_SIZE,
-	     "SoftSIM: "
-	     "Heap memory pool size is not valid. "
-	     "Please reconfigure the project.");
+BUILD_ASSERT(K_HEAP_MEM_POOL_SIZE >= EXPECTED_MIN_HEAP_SIZE, "SoftSIM: "
+							     "Heap memory pool size is not valid. "
+							     "Please reconfigure the project.");
 
 /* In NCS, when NVS backend for Settings is chosen, `nvs_partition` partition is not included by
  * the Partition Manager.

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -100,7 +100,8 @@ int nrf_softsim_init(void)
 	k_work_queue_start(&softsim_work_q, softsim_stack_area,
 			   K_THREAD_STACK_SIZEOF(softsim_stack_area), SOFTSIM_PRIORITY, NULL);
 
-	ctx = ss_new_ctx(); /* TODO: consider dropping this call here */
+	/* The SIM context (~5 KB of heap) is allocated lazily by the
+	 * NRF_MODEM_SOFTSIM_INIT request, not here. */
 
 	LOG_INF("SoftSIM initialized");
 	return 0;
@@ -221,11 +222,26 @@ static void softsim_req_task(struct k_work *item)
 	struct softsim_req_node *s_req;
 
 	while ((s_req = k_fifo_get(&softsim_req_fifo, K_NO_WAIT))) {
+		/* The context is allocated by INIT, which the modem sends first;
+		 * APDU and RESET dereference it and cannot run without it. */
+		if (!ctx && (s_req->req == NRF_MODEM_SOFTSIM_APDU ||
+			     s_req->req == NRF_MODEM_SOFTSIM_RESET)) {
+			LOG_ERR("SoftSIM request %d before INIT", s_req->req);
+			nrf_modem_softsim_err(s_req->req, s_req->req_id);
+			goto free_node;
+		}
+
 		switch (s_req->req) {
 		case NRF_MODEM_SOFTSIM_INIT: {
 			LOG_DBG("SoftSIM INIT REQ");
 			if (!ctx) { /* Check needed since multiple INIT requests can be sent */
 				ctx = ss_new_ctx();
+			}
+
+			if (!ctx) { /* ss_is_suspended(NULL) is 0; ss_reset(NULL) crashes */
+				LOG_ERR("SoftSIM context allocation failed");
+				nrf_modem_softsim_err(s_req->req, s_req->req_id);
+				goto free_node;
 			}
 
 			if (!ss_is_suspended(ctx)) {
@@ -297,6 +313,7 @@ static void softsim_req_task(struct k_work *item)
 			break;
 		}
 
+free_node:
 		/* Free the payload data of the request node if allocated */
 		if (s_req->payload.data) {
 			nrf_modem_softsim_data_free(s_req->payload.data);

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -23,10 +23,9 @@
 LOG_MODULE_REGISTER(softsim, CONFIG_SOFTSIM_NRF_LOG_LEVEL);
 
 /* SoftSIM memory configuration */
-#define SOFTSIM_STACK_SIZE 10000 /* TODO: Figure out some more reasonable value. */
-#define SOFTSIM_PRIORITY   5     /* TODO: What is a good balance here? */
+#define SOFTSIM_PRIORITY 5 /* TODO: What is a good balance here? */
 
-K_THREAD_STACK_DEFINE(softsim_stack_area, SOFTSIM_STACK_SIZE);
+K_THREAD_STACK_DEFINE(softsim_stack_area, CONFIG_SOFTSIM_STACK_SIZE);
 
 #define SIM_HAL_MAX_LE 260
 

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -38,7 +38,6 @@ static void nrf_modem_softsim_req_handler(enum nrf_modem_softsim_cmd req, uint16
 static struct k_work_q softsim_work_q;
 static K_FIFO_DEFINE(softsim_req_fifo);
 static K_WORK_DEFINE(softsim_req_work, softsim_req_task);
-static uint8_t softsim_buffer_out[SIM_HAL_MAX_LE];
 
 #ifdef CONFIG_SOFTSIM_FACTORY_RESET_ON_PROVISION
 static bool just_provisioned;
@@ -220,6 +219,7 @@ static void softsim_req_task(struct k_work *item)
 {
 	int err;
 	struct softsim_req_node *s_req;
+	uint8_t softsim_buffer_out[SIM_HAL_MAX_LE];
 
 	while ((s_req = k_fifo_get(&softsim_req_fifo, K_NO_WAIT))) {
 		/* The context is allocated by INIT, which the modem sends first;

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -310,6 +310,9 @@ static void softsim_req_task(struct k_work *item)
 			break;
 		}
 		default:
+			/* Never leave the modem waiting on a req_id. */
+			LOG_ERR("SoftSIM unknown request: %d", s_req->req);
+			nrf_modem_softsim_err(s_req->req, s_req->req_id);
 			break;
 		}
 

--- a/lib/ss_crypto.c
+++ b/lib/ss_crypto.c
@@ -33,7 +33,6 @@ enum key_identifier_base key_id_to_kmu_slot(uint8_t key_id)
 }
 
 #define SHARED_BUFFER_SIZE 256
-static uint8_t shared_buffer[SHARED_BUFFER_SIZE];
 
 #define ASSERT_STATUS(actual, expected)                                                            \
 	do {                                                                                       \
@@ -166,7 +165,7 @@ void ss_utils_aes_decrypt(uint8_t *buffer, size_t buffer_len, const uint8_t *key
 
 	psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
 	uint8_t iv[AES_BLOCKSIZE] = {0}; /* per standards in telco.. */
-	uint8_t *decrypted_buffer = shared_buffer;
+	uint8_t decrypted_buffer[SHARED_BUFFER_SIZE];
 
 	uint32_t out_len = 0;
 
@@ -200,7 +199,7 @@ void ss_utils_aes_encrypt(uint8_t *buffer, size_t buffer_len, const uint8_t *key
 
 	psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
 	uint8_t iv[AES_BLOCKSIZE] = {0}; /* per standards in telco... */
-	uint8_t *encrypted_buffer = shared_buffer;
+	uint8_t encrypted_buffer[SHARED_BUFFER_SIZE];
 	uint32_t out_len = 0;
 
 	status = psa_cipher_encrypt_setup(&operation, slot_id, PSA_ALG_CBC_NO_PADDING);

--- a/overlay-softsim.conf
+++ b/overlay-softsim.conf
@@ -18,9 +18,8 @@ CONFIG_FLASH_MAP=y
 CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
-# Stack and Heap Configurations
-CONFIG_MAIN_STACK_SIZE=5000
-CONFIG_HEAP_MEM_POOL_SIZE=30000
+# Stack and heap sizing lives in Kconfig defaults (see Kconfig) so an
+# application prj.conf can override it.
 
 # TF-M Configurations
 CONFIG_BUILD_WITH_TFM=y

--- a/tests/handler/src/main.c
+++ b/tests/handler/src/main.c
@@ -417,14 +417,13 @@ ZTEST(softsim_handler, test_an_unknown_command_is_still_answered)
 ZTEST_EXPECT_FAIL(softsim_handler, test_an_unknown_command_is_still_answered);
 
 /*
- * Known defect. DEINIT clears ctx and guards its own use of it, but the RESET
- * case calls ss_reset(ctx) unguarded -- and the modem sends RESET exactly when
- * a request has become unresponsive, which is when ordering is least
- * predictable. On target ss_reset() dereferences immediately.
+ * The modem sends RESET exactly when a request has become unresponsive, which
+ * is when ordering is least predictable -- so a RESET (or APDU) arriving
+ * without a context must be answered with an error, never handed to
+ * ss_reset(), which dereferences immediately on target.
  *
  * Asserted against the fake's recorded argument rather than by letting it
- * crash, so the suite reports the defect instead of taking the process down.
- * Expected to fail until RESET gets the same NULL guard DEINIT already has.
+ * crash, so the suite reports a regression instead of taking the process down.
  */
 ZTEST(softsim_handler, test_reset_never_receives_a_null_context)
 {
@@ -448,13 +447,11 @@ ZTEST(softsim_handler, test_reset_never_receives_a_null_context)
 				 "ss_reset() call %u received a NULL context", i);
 	}
 }
-ZTEST_EXPECT_FAIL(softsim_handler, test_reset_never_receives_a_null_context);
 
 /*
  * Same class, different entry point: ss_new_ctx() returns NULL when the heap is
- * exhausted, and ss_is_suspended(NULL) deliberately answers 0, so the guard in
- * the INIT case passes and ss_reset(NULL) runs. Expected to fail until INIT
- * checks the allocation.
+ * exhausted, and ss_is_suspended(NULL) deliberately answers 0 -- so INIT must
+ * check the allocation itself before the reset path runs.
  */
 ZTEST(softsim_handler, test_init_handles_context_allocation_failure)
 {
@@ -467,7 +464,6 @@ ZTEST(softsim_handler, test_init_handles_context_allocation_failure)
 	zassert_equal(ss_reset_fake.call_count, 0,
 		      "a failed context allocation must not reach ss_reset()");
 }
-ZTEST_EXPECT_FAIL(softsim_handler, test_init_handles_context_allocation_failure);
 
 /* ===========================================================================
  * nrf_softsim_provision(): the validation layer over the profile parser.

--- a/tests/handler/src/main.c
+++ b/tests/handler/src/main.c
@@ -410,11 +410,10 @@ ZTEST(softsim_handler, test_a_deep_burst_is_drained_completely)
 /* --- the NULL-context orderings -------------------------------------------- */
 
 /*
- * Known defect. The command enum has a gap at value 2 (INIT=1, APDU=3,
- * DEINIT=4, RESET=5), and the handler's default case answers nothing at all --
- * no response, no error -- so the modem is left waiting on a req_id that will
- * never come back. Any command the modem gains in a future firmware lands here.
- * Expected to fail until the default case answers with nrf_modem_softsim_err().
+ * The command enum has a gap at value 2 (INIT=1, APDU=3, DEINIT=4, RESET=5),
+ * and any command the modem gains in a future firmware lands in the default
+ * case -- which must answer with nrf_modem_softsim_err() so the modem is never
+ * left waiting on a req_id.
  */
 ZTEST(softsim_handler, test_an_unknown_command_is_still_answered)
 {
@@ -426,7 +425,6 @@ ZTEST(softsim_handler, test_an_unknown_command_is_still_answered)
 
 	zassert_equal(completions(), 1, "an unknown command left the modem without an answer");
 }
-ZTEST_EXPECT_FAIL(softsim_handler, test_an_unknown_command_is_still_answered);
 
 /*
  * The modem sends RESET exactly when a request has become unresponsive, which

--- a/tests/handler/src/main.c
+++ b/tests/handler/src/main.c
@@ -193,6 +193,22 @@ static int completions(void)
 	return nrf_modem_softsim_res_fake.call_count + nrf_modem_softsim_err_fake.call_count;
 }
 
+/* The real nrf_modem_softsim_res() copies the response during the call (the
+ * handler may answer out of stack memory), so a test that wants the bytes must
+ * snapshot them at call time instead of dereferencing arg2_val afterwards. */
+static uint8_t res_snapshot[260]; /* SIM_HAL_MAX_LE in nrf_softsim.c */
+static uint16_t res_snapshot_len;
+
+static int res_snapshot_fake(enum nrf_modem_softsim_cmd cmd, uint16_t req_id, const void *data,
+			     uint16_t len)
+{
+	res_snapshot_len = len;
+	if (data && len <= sizeof(res_snapshot)) {
+		memcpy(res_snapshot, data, len);
+	}
+	return 0;
+}
+
 /* The work queue is a real thread; wait for it rather than sleeping blindly. */
 static void wait_for_completions(int expected)
 {
@@ -234,24 +250,23 @@ ZTEST(softsim_handler, test_each_request_is_answered_exactly_once)
 }
 
 /*
- * The handler answers out of one static buffer for both the ATR and every APDU
- * response, and narrows the core's size_t length into the modem's uint16_t. That
- * plumbing is what the modem actually consumes, so pin the bytes and the length,
- * not just the call count.
+ * The handler answers the ATR and every APDU response out of a buffer on its
+ * own work-queue stack, and narrows the core's size_t length into the modem's
+ * uint16_t. That plumbing is what the modem actually consumes, so pin the
+ * bytes and the length via a call-time snapshot, not just the call count.
  */
 ZTEST(softsim_handler, test_answers_carry_the_core_response_bytes)
 {
-	const uint8_t *out;
+	nrf_modem_softsim_res_fake.custom_fake = res_snapshot_fake;
 
 	submit(NRF_MODEM_SOFTSIM_INIT, 1, NULL, 0);
 	wait_for_completions(1);
 
 	/* atr_ok() fills 8 bytes of 0x3b and returns 8. */
-	zassert_equal(nrf_modem_softsim_res_fake.arg3_val, 8, "ATR length was not passed through");
-	out = nrf_modem_softsim_res_fake.arg2_val;
-	zassert_not_null(out, "INIT must answer with the ATR buffer");
+	zassert_equal(res_snapshot_len, 8, "ATR length was not passed through");
 	for (int i = 0; i < 8; i++) {
-		zassert_equal(out[i], 0x3b, "ATR byte %d differs from what the core produced", i);
+		zassert_equal(res_snapshot[i], 0x3b,
+			      "ATR byte %d differs from what the core produced", i);
 	}
 
 	uint8_t *apdu = k_malloc(4);
@@ -262,12 +277,9 @@ ZTEST(softsim_handler, test_answers_carry_the_core_response_bytes)
 	wait_for_completions(2);
 
 	/* apdu_ok() fills 2 bytes of 0x90 and returns 2. */
-	zassert_equal(nrf_modem_softsim_res_fake.arg3_val, 2,
-		      "APDU response length was not passed through");
-	out = nrf_modem_softsim_res_fake.arg2_val;
-	zassert_not_null(out, "APDU must answer with the response buffer");
-	zassert_equal(out[0], 0x90, "APDU response byte 0 differs");
-	zassert_equal(out[1], 0x90, "APDU response byte 1 differs");
+	zassert_equal(res_snapshot_len, 2, "APDU response length was not passed through");
+	zassert_equal(res_snapshot[0], 0x90, "APDU response byte 0 differs");
+	zassert_equal(res_snapshot[1], 0x90, "APDU response byte 1 differs");
 
 	/* DEINIT has nothing to say and must not point the modem at the buffer. */
 	submit(NRF_MODEM_SOFTSIM_DEINIT, 3, NULL, 0);


### PR DESCRIPTION
The stack/heap requirements imposed on integrating apps become overridable Kconfig options, and the defaults drop to measured values: SoftSIM workqueue stack 10000 -> 6000 and heap (plus its build-assert floor) 30000 -> 24000, based on on-target measurement over provisioning, attach and 12 re-attach cycles (heap peak 17.9 KB, stack high-water 2.2 KB). Also defers the SIM context allocation to the modem INIT request, moves scratch buffers off .bss, sizes SS_STORAGE_PATH_MAX to real paths, and adds docs/memory.md with the measured budget.