### PR TITLE
perf: make SoftSIM stack and heap sizing kconfig overridable

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -140,6 +140,18 @@ endif #SOFTSIM
 
 endmenu
 
+# Top-level (not under `if SOFTSIM`) so autoconf defines it in every build,
+# including the native_sim unit-test builds that compile nrf_softsim.c without
+# CONFIG_SOFTSIM — same reason the log-level symbols below live here.
+config SOFTSIM_STACK_SIZE
+    int "SoftSIM work-queue thread stack size"
+    default 10000
+    help
+        Stack size of the dedicated work-queue thread that runs all SoftSIM
+        processing (ATR, APDU transactions, filesystem and crypto). The
+        default is deliberately generous; measure the high-water mark with
+        CONFIG_THREAD_ANALYZER before lowering it in a product build.
+
 # Conditional defaults for per-layer log levels — placed BEFORE each template
 # source so they win over the template's `default LOG_DEFAULT_LEVEL` fallback
 # (Kconfig: first matching default wins).
@@ -161,6 +173,15 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 # bumps them; otherwise the production-friendly sizing applies. These are
 # `default` directives so any explicit value in a prj.conf or overlay wins.
 if SOFTSIM
+
+# Stack/heap sizing SoftSIM needs on top of Zephyr's defaults. Previously hard
+# assignments in overlay-softsim.conf, which an application prj.conf could not
+# lower; as `default` directives any explicit value wins.
+config MAIN_STACK_SIZE
+    default 5000
+
+config HEAP_MEM_POOL_SIZE
+    default 30000
 
 config LOG_DEFAULT_LEVEL
     default 1

--- a/Kconfig
+++ b/Kconfig
@@ -174,13 +174,10 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 # `default` directives so any explicit value in a prj.conf or overlay wins.
 if SOFTSIM
 
-# Stack/heap sizing SoftSIM needs on top of Zephyr's defaults. Previously hard
-# assignments in overlay-softsim.conf, which an application prj.conf could not
-# lower; as `default` directives any explicit value wins.
-config MAIN_STACK_SIZE
-    default 5000
-
-config HEAP_MEM_POOL_SIZE
+# Heap contribution, summed into K_HEAP_MEM_POOL_SIZE: raises a smaller
+# application heap instead of losing to it like a plain `default` would.
+config HEAP_MEM_POOL_ADD_SIZE_SOFTSIM
+    int
     default 30000
 
 config LOG_DEFAULT_LEVEL

--- a/lib/build_asserts.c
+++ b/lib/build_asserts.c
@@ -18,10 +18,11 @@
 BUILD_ASSERT(2 * KEY_SIZE <= A001_LEN, "SoftSIM: A001 layout changed");
 BUILD_ASSERT(A004_HEADER_SIZE + 2 * KEY_SIZE <= A004_LEN, "SoftSIM: A004 layout changed");
 
-BUILD_ASSERT(CONFIG_HEAP_MEM_POOL_SIZE >= EXPECTED_MIN_HEAP_SIZE,
-	     "SoftSIM: "
-	     "Heap memory pool size is not valid. "
-	     "Please reconfigure the project.");
+/* Effective heap size (includes the ADD_SIZE contributions); only trips when
+ * HEAP_MEM_POOL_IGNORE_MIN bypasses them. */
+BUILD_ASSERT(K_HEAP_MEM_POOL_SIZE >= EXPECTED_MIN_HEAP_SIZE, "SoftSIM: "
+							     "Heap memory pool size is not valid. "
+							     "Please reconfigure the project.");
 
 /* In NCS, when NVS backend for Settings is chosen, `nvs_partition` partition is not included by
  * the Partition Manager.

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -23,10 +23,9 @@
 LOG_MODULE_REGISTER(softsim, CONFIG_SOFTSIM_NRF_LOG_LEVEL);
 
 /* SoftSIM memory configuration */
-#define SOFTSIM_STACK_SIZE 10000 /* TODO: Figure out some more reasonable value. */
-#define SOFTSIM_PRIORITY   5     /* TODO: What is a good balance here? */
+#define SOFTSIM_PRIORITY 5 /* TODO: What is a good balance here? */
 
-K_THREAD_STACK_DEFINE(softsim_stack_area, SOFTSIM_STACK_SIZE);
+K_THREAD_STACK_DEFINE(softsim_stack_area, CONFIG_SOFTSIM_STACK_SIZE);
 
 #define SIM_HAL_MAX_LE 260
 

--- a/overlay-softsim.conf
+++ b/overlay-softsim.conf
@@ -18,8 +18,9 @@ CONFIG_FLASH_MAP=y
 CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
-# Stack and heap sizing lives in Kconfig defaults (see Kconfig) so an
-# application prj.conf can override it.
+# Auto-init runs SoftSIM fs init on the main stack (SYS_INIT); hard assignment
+# so a smaller application value can't overflow it. Heap sizing: see Kconfig.
+CONFIG_MAIN_STACK_SIZE=5000
 
 # TF-M Configurations
 CONFIG_BUILD_WITH_TFM=y

--- a/overlay-softsim.conf
+++ b/overlay-softsim.conf
@@ -18,9 +18,8 @@ CONFIG_FLASH_MAP=y
 CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
-# Stack and Heap Configurations
-CONFIG_MAIN_STACK_SIZE=5000
-CONFIG_HEAP_MEM_POOL_SIZE=30000
+# Stack and heap sizing lives in Kconfig defaults (see Kconfig) so an
+# application prj.conf can override it.
 
 # TF-M Configurations
 CONFIG_BUILD_WITH_TFM=y


### PR DESCRIPTION
First slice of #187.

Makes SoftSIM stack/heap sizing overridable by the application. All effective values are unchanged for the sample and the documented integration path.

- `CONFIG_SOFTSIM_STACK_SIZE` (default 10000) replaces the hardcoded stack define.
- Heap is now declared via `CONFIG_HEAP_MEM_POOL_ADD_SIZE_SOFTSIM=30000` instead of a hard `CONFIG_HEAP_MEM_POOL_SIZE=30000`, so an application asking for more heap actually gets it. A plain Kconfig `default` doesn't work here since it loses to any explicit prj.conf value (CI caught this via at_client's 16384 setting).
- `CONFIG_MAIN_STACK_SIZE=5000` stays hardcoded for now — auto-init runs SoftSIM filesystem init on the main stack, and 5000 is the only size proven on hardware. Making it overridable is deferred to a later #187 slice.
