### PR TITLE
fix: pin the profile CRC32 verification during provisioning

### DIFF
--- a/docs/provisioning.md
+++ b/docs/provisioning.md
@@ -20,10 +20,19 @@ characters — `LEN` counts hex characters, not bytes):
 | `07` | SMSP | SMS parameters (optional) |
 | `08`–`0b` | PIN1, PIN2, ADM, PUK | PIN values |
 | `0c` | SMSC | SMS service-center address (optional) |
+| `fe` | CRC32 | Integrity check over everything before it (optional, must be last) |
 
 The full tag list and the decoder (`ss_profile_from_string()`) live in onomondo-uicc, in
 [`ss_profile.h`](https://github.com/onomondo/onomondo-uicc/blob/master/include/onomondo/utils/ss_profile.h)
 and [`utils/ss_profile.c`](https://github.com/onomondo/onomondo-uicc/blob/master/utils/ss_profile.c).
+
+The CRC32 record carries the CRC-32/ISO-HDLC (zlib) checksum of every preceding character
+as 8 hex chars, computed after lowercasing so a transport that re-cases the string does
+not invalidate it. When the record is present, provisioning verifies it and
+`nrf_softsim_provision()` fails on a mismatch — before any key or file is written; a
+profile without the record provisions as before, so existing profiles keep working. The
+[onomondo-softsim-cli](https://github.com/onomondo/onomondo-softsim-cli) appends the
+record by default.
 
 The sample's [`prj.conf`](../samples/softsim_external_profile/prj.conf) carries the GSMA
 TS.48 standard USIM test profile in a comment. It lets the SIM initialize and is useful

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -133,7 +133,12 @@ int nrf_softsim_provision(uint8_t *profile_r, size_t len)
 	uint8_t decode_err =
 		ss_profile_from_string((uint16_t)len, (const char *)profile_r, &profile);
 	if (decode_err != 0) {
-		LOG_ERR("SoftSIM profile decode failed (err %u)", decode_err);
+		/* 18 and 19 are the CRC32 record errors -- see ss_profile.h. */
+		if (decode_err == 18 || decode_err == 19) {
+			LOG_ERR("SoftSIM profile failed its CRC32 check (err %u)", decode_err);
+		} else {
+			LOG_ERR("SoftSIM profile decode failed (err %u)", decode_err);
+		}
 		return -1;
 	}
 

--- a/tests/handler/src/main.c
+++ b/tests/handler/src/main.c
@@ -651,3 +651,44 @@ ZTEST(softsim_provision, test_known_tag_with_the_wrong_length_is_rejected)
 	zassert_equal(port_provision_fake.call_count, 0);
 	zassert_equal(key_setup.count, 0);
 }
+
+/* Copy the TS.48 vector into dst and append a trailing CRC32 record carrying
+ * the given value. Returns the new length. dst must hold at least
+ * sizeof(ts48_profile) + 12 chars. */
+static size_t with_crc_record(uint32_t crc, char *dst)
+{
+	size_t len = sizeof(ts48_profile) - 1;
+
+	memcpy(dst, ts48_profile, len);
+	return len + (size_t)snprintk(&dst[len], 13, "%02x%02x%08x", CRC32_TAG, CRC32_LEN, crc);
+}
+
+/*
+ * The optional trailing CRC32 record comes with the parser; its algorithm and
+ * edge cases are pinned upstream (onomondo-uicc tests/utils). These two pin
+ * the glue: a profile whose record matches provisions as usual, and a mismatch
+ * fails the provisioning before anything reaches the KMU or the filesystem.
+ * The record is built from ss_profile_crc32() itself, so the pair stays valid
+ * if the algorithm ever changes -- what it pins is match vs. mismatch.
+ */
+ZTEST(softsim_provision, test_profile_with_matching_crc_provisions)
+{
+	char buf[sizeof(ts48_profile) + 12];
+	size_t len = with_crc_record(ss_profile_crc32(ts48_profile, sizeof(ts48_profile) - 1), buf);
+
+	zassert_ok(nrf_softsim_provision((uint8_t *)buf, len));
+	zassert_equal(port_provision_fake.call_count, 1);
+	zassert_equal(key_setup.count, 3);
+}
+
+ZTEST(softsim_provision, test_profile_with_bad_crc_is_rejected)
+{
+	char buf[sizeof(ts48_profile) + 12];
+	size_t len =
+		with_crc_record(ss_profile_crc32(ts48_profile, sizeof(ts48_profile) - 1) ^ 1, buf);
+
+	zassert_true(nrf_softsim_provision((uint8_t *)buf, len) != 0,
+		     "a profile with a mismatching CRC32 record was accepted");
+	zassert_equal(port_provision_fake.call_count, 0);
+	zassert_equal(key_setup.count, 0);
+}


### PR DESCRIPTION
A SoftSIM profile can now end with a CRC32 record — tag `fe`, length `08`, and the CRC-32/ISO-HDLC checksum of every preceding character as 8 hex chars. Provisioning verifies the record when present and fails before any key or file is written when it does not match; a profile without the record provisions exactly as before, so nothing changes for existing fleets. [onomondo-softsim-cli](https://github.com/onomondo/onomondo-softsim-cli) appends the record by default, so freshly fetched profiles are covered end to end.

Closes: https://github.com/onomondo/nrf-softsim/issues/83