### PR TITLE
perf: defer SIM context allocation to the modem INIT request

### DIFF
--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -101,7 +101,8 @@ int nrf_softsim_init(void)
 	k_work_queue_start(&softsim_work_q, softsim_stack_area,
 			   K_THREAD_STACK_SIZEOF(softsim_stack_area), SOFTSIM_PRIORITY, NULL);
 
-	ctx = ss_new_ctx(); /* TODO: consider dropping this call here */
+	/* The SIM context (~5 KB of heap) is allocated lazily by the
+	 * NRF_MODEM_SOFTSIM_INIT request, not here. */
 
 	LOG_INF("SoftSIM initialized");
 	return 0;
@@ -227,11 +228,26 @@ static void softsim_req_task(struct k_work *item)
 	struct softsim_req_node *s_req;
 
 	while ((s_req = k_fifo_get(&softsim_req_fifo, K_NO_WAIT))) {
+		/* The context is allocated by INIT, which the modem sends first;
+		 * APDU and RESET dereference it and cannot run without it. */
+		if (!ctx && (s_req->req == NRF_MODEM_SOFTSIM_APDU ||
+			     s_req->req == NRF_MODEM_SOFTSIM_RESET)) {
+			LOG_ERR("SoftSIM request %d before INIT", s_req->req);
+			nrf_modem_softsim_err(s_req->req, s_req->req_id);
+			goto free_node;
+		}
+
 		switch (s_req->req) {
 		case NRF_MODEM_SOFTSIM_INIT: {
 			LOG_DBG("SoftSIM INIT REQ");
 			if (!ctx) { /* Check needed since multiple INIT requests can be sent */
 				ctx = ss_new_ctx();
+			}
+
+			if (!ctx) { /* ss_is_suspended(NULL) is 0; ss_reset(NULL) crashes */
+				LOG_ERR("SoftSIM context allocation failed");
+				nrf_modem_softsim_err(s_req->req, s_req->req_id);
+				goto free_node;
 			}
 
 			if (!ss_is_suspended(ctx)) {
@@ -303,6 +319,7 @@ static void softsim_req_task(struct k_work *item)
 			break;
 		}
 
+free_node:
 		/* Free the payload data of the request node if allocated */
 		if (s_req->payload.data) {
 			nrf_modem_softsim_data_free(s_req->payload.data);

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -101,9 +101,6 @@ int nrf_softsim_init(void)
 	k_work_queue_start(&softsim_work_q, softsim_stack_area,
 			   K_THREAD_STACK_SIZEOF(softsim_stack_area), SOFTSIM_PRIORITY, NULL);
 
-	/* The SIM context (~5 KB of heap) is allocated lazily by the
-	 * NRF_MODEM_SOFTSIM_INIT request, not here. */
-
 	LOG_INF("SoftSIM initialized");
 	return 0;
 }

--- a/tests/handler/src/main.c
+++ b/tests/handler/src/main.c
@@ -417,14 +417,13 @@ ZTEST(softsim_handler, test_an_unknown_command_is_still_answered)
 ZTEST_EXPECT_FAIL(softsim_handler, test_an_unknown_command_is_still_answered);
 
 /*
- * Known defect. DEINIT clears ctx and guards its own use of it, but the RESET
- * case calls ss_reset(ctx) unguarded -- and the modem sends RESET exactly when
- * a request has become unresponsive, which is when ordering is least
- * predictable. On target ss_reset() dereferences immediately.
+ * The modem sends RESET exactly when a request has become unresponsive, which
+ * is when ordering is least predictable -- so a RESET (or APDU) arriving
+ * without a context must be answered with an error, never handed to
+ * ss_reset(), which dereferences immediately on target.
  *
  * Asserted against the fake's recorded argument rather than by letting it
- * crash, so the suite reports the defect instead of taking the process down.
- * Expected to fail until RESET gets the same NULL guard DEINIT already has.
+ * crash, so the suite reports a regression instead of taking the process down.
  */
 ZTEST(softsim_handler, test_reset_never_receives_a_null_context)
 {
@@ -448,13 +447,11 @@ ZTEST(softsim_handler, test_reset_never_receives_a_null_context)
 				 "ss_reset() call %u received a NULL context", i);
 	}
 }
-ZTEST_EXPECT_FAIL(softsim_handler, test_reset_never_receives_a_null_context);
 
 /*
  * Same class, different entry point: ss_new_ctx() returns NULL when the heap is
- * exhausted, and ss_is_suspended(NULL) deliberately answers 0, so the guard in
- * the INIT case passes and ss_reset(NULL) runs. Expected to fail until INIT
- * checks the allocation.
+ * exhausted, and ss_is_suspended(NULL) deliberately answers 0 -- so INIT must
+ * check the allocation itself before the reset path runs.
  */
 ZTEST(softsim_handler, test_init_handles_context_allocation_failure)
 {
@@ -467,7 +464,6 @@ ZTEST(softsim_handler, test_init_handles_context_allocation_failure)
 	zassert_equal(ss_reset_fake.call_count, 0,
 		      "a failed context allocation must not reach ss_reset()");
 }
-ZTEST_EXPECT_FAIL(softsim_handler, test_init_handles_context_allocation_failure);
 
 /* ===========================================================================
  * nrf_softsim_provision(): the validation layer over the profile parser.


### PR DESCRIPTION
Spin-off from #187, self-contained on master.

`nrf_softsim_init()` eagerly allocated the ~5 KB SIM context that the modem's INIT request already allocates on demand — dropped (the code carried a TODO for exactly this). APDU/RESET arriving before INIT, and INIT with a failed allocation, now answer `nrf_modem_softsim_err()` instead of dereferencing NULL (`ss_is_suspended(NULL)` answers 0, so the old flow reached `ss_reset(NULL)`). The two matching handler tests flip from expected-fail to regression guards.