### PR TITLE
perf: move single-user scratch buffers off .bss

### DIFF
--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -39,7 +39,6 @@ static void nrf_modem_softsim_req_handler(enum nrf_modem_softsim_cmd req, uint16
 static struct k_work_q softsim_work_q;
 static K_FIFO_DEFINE(softsim_req_fifo);
 static K_WORK_DEFINE(softsim_req_work, softsim_req_task);
-static uint8_t softsim_buffer_out[SIM_HAL_MAX_LE];
 
 #ifdef CONFIG_SOFTSIM_FACTORY_RESET_ON_PROVISION
 static bool just_provisioned;
@@ -225,6 +224,7 @@ static void softsim_req_task(struct k_work *item)
 {
 	int err;
 	struct softsim_req_node *s_req;
+	uint8_t softsim_buffer_out[SIM_HAL_MAX_LE];
 
 	while ((s_req = k_fifo_get(&softsim_req_fifo, K_NO_WAIT))) {
 		switch (s_req->req) {

--- a/lib/ss_crypto.c
+++ b/lib/ss_crypto.c
@@ -33,7 +33,6 @@ enum key_identifier_base key_id_to_kmu_slot(uint8_t key_id)
 }
 
 #define SHARED_BUFFER_SIZE 256
-static uint8_t shared_buffer[SHARED_BUFFER_SIZE];
 
 #define ASSERT_STATUS(actual, expected)                                                            \
 	do {                                                                                       \
@@ -166,7 +165,7 @@ void ss_utils_aes_decrypt(uint8_t *buffer, size_t buffer_len, const uint8_t *key
 
 	psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
 	uint8_t iv[AES_BLOCKSIZE] = {0}; /* per standards in telco.. */
-	uint8_t *decrypted_buffer = shared_buffer;
+	uint8_t decrypted_buffer[SHARED_BUFFER_SIZE];
 
 	uint32_t out_len = 0;
 
@@ -200,7 +199,7 @@ void ss_utils_aes_encrypt(uint8_t *buffer, size_t buffer_len, const uint8_t *key
 
 	psa_cipher_operation_t operation = PSA_CIPHER_OPERATION_INIT;
 	uint8_t iv[AES_BLOCKSIZE] = {0}; /* per standards in telco... */
-	uint8_t *encrypted_buffer = shared_buffer;
+	uint8_t encrypted_buffer[SHARED_BUFFER_SIZE];
 	uint32_t out_len = 0;
 
 	status = psa_cipher_encrypt_setup(&operation, slot_id, PSA_ALG_CBC_NO_PADDING);

--- a/tests/handler/src/main.c
+++ b/tests/handler/src/main.c
@@ -193,6 +193,22 @@ static int completions(void)
 	return nrf_modem_softsim_res_fake.call_count + nrf_modem_softsim_err_fake.call_count;
 }
 
+/* The real nrf_modem_softsim_res() copies the response during the call (the
+ * handler may answer out of stack memory), so a test that wants the bytes must
+ * snapshot them at call time instead of dereferencing arg2_val afterwards. */
+static uint8_t res_snapshot[260]; /* SIM_HAL_MAX_LE in nrf_softsim.c */
+static uint16_t res_snapshot_len;
+
+static int res_snapshot_fake(enum nrf_modem_softsim_cmd cmd, uint16_t req_id, const void *data,
+			     uint16_t len)
+{
+	res_snapshot_len = len;
+	if (data && len <= sizeof(res_snapshot)) {
+		memcpy(res_snapshot, data, len);
+	}
+	return 0;
+}
+
 /* The work queue is a real thread; wait for it rather than sleeping blindly. */
 static void wait_for_completions(int expected)
 {
@@ -234,24 +250,23 @@ ZTEST(softsim_handler, test_each_request_is_answered_exactly_once)
 }
 
 /*
- * The handler answers out of one static buffer for both the ATR and every APDU
- * response, and narrows the core's size_t length into the modem's uint16_t. That
- * plumbing is what the modem actually consumes, so pin the bytes and the length,
- * not just the call count.
+ * The handler answers the ATR and every APDU response out of a buffer on its
+ * own work-queue stack, and narrows the core's size_t length into the modem's
+ * uint16_t. That plumbing is what the modem actually consumes, so pin the
+ * bytes and the length via a call-time snapshot, not just the call count.
  */
 ZTEST(softsim_handler, test_answers_carry_the_core_response_bytes)
 {
-	const uint8_t *out;
+	nrf_modem_softsim_res_fake.custom_fake = res_snapshot_fake;
 
 	submit(NRF_MODEM_SOFTSIM_INIT, 1, NULL, 0);
 	wait_for_completions(1);
 
 	/* atr_ok() fills 8 bytes of 0x3b and returns 8. */
-	zassert_equal(nrf_modem_softsim_res_fake.arg3_val, 8, "ATR length was not passed through");
-	out = nrf_modem_softsim_res_fake.arg2_val;
-	zassert_not_null(out, "INIT must answer with the ATR buffer");
+	zassert_equal(res_snapshot_len, 8, "ATR length was not passed through");
 	for (int i = 0; i < 8; i++) {
-		zassert_equal(out[i], 0x3b, "ATR byte %d differs from what the core produced", i);
+		zassert_equal(res_snapshot[i], 0x3b,
+			      "ATR byte %d differs from what the core produced", i);
 	}
 
 	uint8_t *apdu = k_malloc(4);
@@ -262,12 +277,9 @@ ZTEST(softsim_handler, test_answers_carry_the_core_response_bytes)
 	wait_for_completions(2);
 
 	/* apdu_ok() fills 2 bytes of 0x90 and returns 2. */
-	zassert_equal(nrf_modem_softsim_res_fake.arg3_val, 2,
-		      "APDU response length was not passed through");
-	out = nrf_modem_softsim_res_fake.arg2_val;
-	zassert_not_null(out, "APDU must answer with the response buffer");
-	zassert_equal(out[0], 0x90, "APDU response byte 0 differs");
-	zassert_equal(out[1], 0x90, "APDU response byte 1 differs");
+	zassert_equal(res_snapshot_len, 2, "APDU response length was not passed through");
+	zassert_equal(res_snapshot[0], 0x90, "APDU response byte 0 differs");
+	zassert_equal(res_snapshot[1], 0x90, "APDU response byte 1 differs");
 
 	/* DEINIT has nothing to say and must not point the modem at the buffer. */
 	submit(NRF_MODEM_SOFTSIM_DEINIT, 3, NULL, 0);


### PR DESCRIPTION
Spin-off from #187, self-contained on master.

The R-APDU buffer and the PSA cipher scratch are each only live inside one function; as stack locals they stop costing 516 B of permanent RAM. The response-bytes handler test now snapshots the payload at call time — the modem API copies during the call, and afterwards `arg2_val` may point at dead stack.