### PR TITLE
feat!: give SoftSIM its own heap

### DIFF
--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -81,12 +81,9 @@ jobs:
       # board-independent, so one board is enough. Runs after the archive so its
       # pristine rebuild doesn't clobber the archived (external) merged.hex.
       #
-      # overlay-heap-stats.conf rides along because this is the only build that
-      # links ss_heap.c and nrf_softsim.c together: the unit tests compile one or
-      # the other, so nothing else compiles the stats path at all. Both greps
-      # check what a compile cannot see -- that the option survived sysbuild's
-      # variable forwarding, and that the log level still lets the line be
-      # emitted (the module pins LOG_DEFAULT_LEVEL to ERR, which muted it once).
+      # overlay-heap-stats.conf rides along: the only build that links ss_heap.c
+      # and nrf_softsim.c, so nothing else compiles the stats path. The greps
+      # check what a compile cannot: the option and the log level survived.
       - name: Build firmware (static profile mode, compile check)
         if: matrix.board == 'nrf9151dk/nrf9151/ns'
         working-directory: modules/lib/onomondo-softsim/samples/softsim_external_profile

--- a/.github/workflows/softsim-build-using-docker.yml
+++ b/.github/workflows/softsim-build-using-docker.yml
@@ -80,12 +80,23 @@ jobs:
       # Compile-check the static-profile mode too. The static vs external delta is
       # board-independent, so one board is enough. Runs after the archive so its
       # pristine rebuild doesn't clobber the archived (external) merged.hex.
+      #
+      # overlay-heap-stats.conf rides along because this is the only build that
+      # links ss_heap.c and nrf_softsim.c together: the unit tests compile one or
+      # the other, so nothing else compiles the stats path at all. Both greps
+      # check what a compile cannot see -- that the option survived sysbuild's
+      # variable forwarding, and that the log level still lets the line be
+      # emitted (the module pins LOG_DEFAULT_LEVEL to ERR, which muted it once).
       - name: Build firmware (static profile mode, compile check)
         if: matrix.board == 'nrf9151dk/nrf9151/ns'
         working-directory: modules/lib/onomondo-softsim/samples/softsim_external_profile
         run: |
           west build --sysbuild --pristine=always --board ${{ matrix.board }} \
-            -- -DEXTRA_CONF_FILE=overlay-static.conf
+            -- -DEXTRA_CONF_FILE="overlay-static.conf;overlay-heap-stats.conf"
+          grep -qx 'CONFIG_SOFTSIM_HEAP_STATS=y' \
+            build/softsim_external_profile/zephyr/.config
+          grep -qE '^CONFIG_SOFTSIM_NRF_LOG_LEVEL=[34]$' \
+            build/softsim_external_profile/zephyr/.config
 
       # The sysbuild hook runs for every sysbuild build in the workspace; hello_world
       # proves it works without the (deprecated, default-off) Partition Manager.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,14 @@
 
 add_subdirectory_ifdef(CONFIG_SOFTSIM lib)
 
+# A kernel pool this large is usually left over from sizing it for SoftSIM.
+# Warn, not assert: an application may legitimately need that much itself.
+if(CONFIG_SOFTSIM AND CONFIG_HEAP_MEM_POOL_SIZE GREATER_EQUAL 30000)
+  message(WARNING "SoftSIM allocates from CONFIG_SOFTSIM_HEAP_SIZE, not the kernel heap. "
+    "CONFIG_HEAP_MEM_POOL_SIZE=${CONFIG_HEAP_MEM_POOL_SIZE} sizes your application's own "
+    "k_malloc use only -- see 'Migrating from 6.1.1 and earlier' in docs/integration.md.")
+endif()
+
 if(CONFIG_SOFTSIM AND NOT CONFIG_PARTITION_MANAGER_ENABLED)
   # Devicetree partitioning: generate the template SoftSIM filesystem hex at
   # the nvs_storage partition address. (With the deprecated Partition Manager

--- a/Kconfig
+++ b/Kconfig
@@ -152,6 +152,24 @@ config SOFTSIM_STACK_SIZE
         default is deliberately generous; measure the high-water mark with
         CONFIG_THREAD_ANALYZER before lowering it in a product build.
 
+config SOFTSIM_HEAP_SIZE
+    int "SoftSIM heap size"
+    range 30000 131072
+    default 30000
+    help
+        Usable bytes in SoftSIM's private heap. Every SoftSIM allocation --
+        SIM context, directory table, file cache, APDU transactions, TLV
+        decode trees, OTA responses -- comes from here and from nowhere else,
+        so an application cannot consume it and SoftSIM cannot consume the
+        application's. As far as this module is concerned
+        CONFIG_HEAP_MEM_POOL_SIZE may be 0.
+
+        The floor is not slack: steady state on the shipped profile is
+        11.5-13 kB and the RFM/OTA path peaks about 10 kB above that (a 4 kB
+        response held live while all 31 concatenated-SMS parts are queued).
+        Do not lower it without a measured high-water mark that covers an
+        RFM/OTA exchange -- see CONFIG_SOFTSIM_HEAP_STATS.
+
 # Conditional defaults for per-layer log levels — placed BEFORE each template
 # source so they win over the template's `default LOG_DEFAULT_LEVEL` fallback
 # (Kconfig: first matching default wins).
@@ -173,12 +191,6 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 # bumps them; otherwise the production-friendly sizing applies. These are
 # `default` directives so any explicit value in a prj.conf or overlay wins.
 if SOFTSIM
-
-# Heap contribution, summed into K_HEAP_MEM_POOL_SIZE: raises a smaller
-# application heap instead of losing to it like a plain `default` would.
-config HEAP_MEM_POOL_ADD_SIZE_SOFTSIM
-    int
-    default 30000
 
 config LOG_DEFAULT_LEVEL
     default 1

--- a/Kconfig
+++ b/Kconfig
@@ -76,10 +76,6 @@ config SOFTSIM_UICC_ENABLE_SANITIZE
     bool "Enable sanitizers in onomondo-uicc"
     default n
 
-config SOFTSIM_UICC_USE_SYSTEM_HEAP
-    bool "Use system malloc/free in onomondo-uicc"
-    default n
-
 config SOFTSIM_UICC_USE_LOGS
     bool "Enable ss_logp logging in onomondo-uicc"
     default y

--- a/Kconfig
+++ b/Kconfig
@@ -166,6 +166,15 @@ config SOFTSIM_HEAP_SIZE
         Do not lower it without a measured high-water mark that covers an
         RFM/OTA exchange -- see CONFIG_SOFTSIM_HEAP_STATS.
 
+config SOFTSIM_HEAP_STATS
+    bool "Log SoftSIM heap usage"
+    select SYS_HEAP_RUNTIME_STATS
+    help
+        Log how much of CONFIG_SOFTSIM_HEAP_SIZE has been used, when the
+        modem deinitialises the SIM. This is the only SoftSIM-only heap
+        figure available: the kernel pool mixes every k_malloc caller in the
+        image. Exercise an RFM/OTA exchange before trusting a peak.
+
 # Conditional defaults for per-layer log levels — placed BEFORE each template
 # source so they win over the template's `default LOG_DEFAULT_LEVEL` fallback
 # (Kconfig: first matching default wins).

--- a/Kconfig
+++ b/Kconfig
@@ -140,6 +140,18 @@ endif #SOFTSIM
 
 endmenu
 
+# Top-level (not under `if SOFTSIM`) so autoconf defines it in every build,
+# including the native_sim unit-test builds that compile nrf_softsim.c without
+# CONFIG_SOFTSIM — same reason the log-level symbols below live here.
+config SOFTSIM_STACK_SIZE
+    int "SoftSIM work-queue thread stack size"
+    default 10000
+    help
+        Stack size of the dedicated work-queue thread that runs all SoftSIM
+        processing (ATR, APDU transactions, filesystem and crypto). The
+        default is deliberately generous; measure the high-water mark with
+        CONFIG_THREAD_ANALYZER before lowering it in a product build.
+
 # Conditional defaults for per-layer log levels — placed BEFORE each template
 # source so they win over the template's `default LOG_DEFAULT_LEVEL` fallback
 # (Kconfig: first matching default wins).
@@ -161,6 +173,15 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 # bumps them; otherwise the production-friendly sizing applies. These are
 # `default` directives so any explicit value in a prj.conf or overlay wins.
 if SOFTSIM
+
+# Stack/heap sizing SoftSIM needs on top of Zephyr's defaults. Previously hard
+# assignments in overlay-softsim.conf, which an application prj.conf could not
+# lower; as `default` directives any explicit value wins.
+config MAIN_STACK_SIZE
+    default 5000
+
+config HEAP_MEM_POOL_SIZE
+    default 30000
 
 config LOG_DEFAULT_LEVEL
     default 1

--- a/Kconfig
+++ b/Kconfig
@@ -174,13 +174,10 @@ source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 # `default` directives so any explicit value in a prj.conf or overlay wins.
 if SOFTSIM
 
-# Stack/heap sizing SoftSIM needs on top of Zephyr's defaults. Previously hard
-# assignments in overlay-softsim.conf, which an application prj.conf could not
-# lower; as `default` directives any explicit value wins.
-config MAIN_STACK_SIZE
-    default 5000
-
-config HEAP_MEM_POOL_SIZE
+# Heap contribution, summed into K_HEAP_MEM_POOL_SIZE: raises a smaller
+# application heap instead of losing to it like a plain `default` would.
+config HEAP_MEM_POOL_ADD_SIZE_SOFTSIM
+    int
     default 30000
 
 config LOG_DEFAULT_LEVEL

--- a/Kconfig
+++ b/Kconfig
@@ -170,16 +170,19 @@ config SOFTSIM_HEAP_STATS
     bool "Log SoftSIM heap usage"
     select SYS_HEAP_RUNTIME_STATS
     help
-        Log how much of CONFIG_SOFTSIM_HEAP_SIZE has been used, when the
-        modem deinitialises the SIM. This is the only SoftSIM-only heap
-        figure available: the kernel pool mixes every k_malloc caller in the
-        image. Exercise an RFM/OTA exchange before trusting a peak.
+        Log the SoftSIM heap high-water mark each time it grows, naming the
+        INS byte of the APDU that caused it. This is the only SoftSIM-only
+        heap figure available: the kernel pool mixes every k_malloc caller in
+        the image. Exercise an RFM/OTA exchange before trusting a peak.
+        Raises CONFIG_SOFTSIM_NRF_LOG_LEVEL to INF, or the line cannot
+        be emitted.
 
 # Conditional defaults for per-layer log levels — placed BEFORE each template
 # source so they win over the template's `default LOG_DEFAULT_LEVEL` fallback
 # (Kconfig: first matching default wins).
 config SOFTSIM_NRF_LOG_LEVEL
     default 4 if SOFTSIM_NRF_DEBUG_LOGS
+    default 3 if SOFTSIM_HEAP_STATS
 
 module = SOFTSIM_NRF
 module-str = Onomondo-SoftSIM-NRF

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -180,7 +180,7 @@ onomondo-uicc reaches the platform through four interfaces, declared in the subm
 |---|---|---|
 | Storage | `storage.h` (+ the `fs.h` shim) | [`ss_fs.c`](../lib/ss_fs.c) + [`ss_cache.c`](../lib/ss_cache.c): Zephyr NVS + RAM cache |
 | Crypto | `crypto.h` | [`ss_crypto.c`](../lib/ss_crypto.c): PSA Crypto, keys by reference (AES/AES-CMAC only — the 3DES entry points are stubs) |
-| Memory | `mem.h` | [`ss_heap.c`](../lib/ss_heap.c): `k_malloc()` / `k_free()` |
+| Memory | `mem.h` | [`ss_heap.c`](../lib/ss_heap.c): a private `k_heap`, sized by `CONFIG_SOFTSIM_HEAP_SIZE` |
 | Logging | `log.h` | [`ss_logp_zephyr.c`](../lib/ss_logp_zephyr.c): Zephyr log module |
 
 `CONFIG_SOFTSIM_UICC_EXTERNAL_CRYPTO_IMPL=y` (the nRF91 default) is what swaps the
@@ -195,7 +195,7 @@ Beyond the port implementations above and
 | Path | Contents |
 |---|---|
 | [`lib/include/nrf_softsim.h`](../lib/include/nrf_softsim.h) | The application API, documented at the source |
-| [`lib/build_asserts.c`](../lib/build_asserts.c) | Compile-time layout checks (32 kB `nvs_storage`, heap floor, settings-partition clash, A001/A004 layout) |
+| [`lib/build_asserts.c`](../lib/build_asserts.c) | Compile-time layout checks (32 kB `nvs_storage`, settings-partition clash, A001/A004 layout) |
 | [`dts/softsim/`](../dts/softsim) | Devicetree partition layouts |
 | [`sysbuild/`](../sysbuild) | Template-hex generation and merging |
 | [`samples/softsim_external_profile/`](../samples/softsim_external_profile) | The reference application |

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -208,14 +208,14 @@ To upgrade firmware while keeping the profile, either:
 
 | Resource | Requirement |
 |---|---|
-| Heap | `CONFIG_HEAP_MEM_POOL_SIZE` ≥ 30000 (build assert). The filesystem cache and working buffers come from the kernel heap; budget on top of your application's own use. |
-| SoftSIM thread | 10 kB stack (`SOFTSIM_STACK_SIZE`). |
+| Heap | SoftSIM allocates from its own heap, `CONFIG_SOFTSIM_HEAP_SIZE` (30000 by default, and its floor). Nothing to budget on top: your `CONFIG_HEAP_MEM_POOL_SIZE` is yours alone, and may be 0 if your application never calls `k_malloc`. |
+| SoftSIM thread | 10 kB stack (`CONFIG_SOFTSIM_STACK_SIZE`). |
 | Flash | 32 kB `nvs_storage` + the TF-M secure region, sized by the devicetree `slot0_s_partition` node: 0x18000 (96 kB) on both nRF91 DK layouts, 0x14000 (80 kB) on Thingy:91, 0x20000 (128 kB) on Thingy:91 X. Large applications may need features trimmed to fit — the linker reports overflow. The same applies to RAM. |
 | TF-M | `CONFIG_BUILD_WITH_TFM=y` is a hard dependency (PSA crypto). The sample shows how to keep it small (`CONFIG_TFM_PARTITION_PROTECTED_STORAGE=n`, `CONFIG_PSA_CRYPTO_DRIVER_CC3XX=n`). |
 
-The build asserts in [`lib/build_asserts.c`](../lib/build_asserts.c) catch the heap floor,
-the partition size and the Settings clash with an explanatory message, so you will be told
-rather than debug it. Two of them need context:
+The build asserts in [`lib/build_asserts.c`](../lib/build_asserts.c) catch the partition
+size and the Settings clash with an explanatory message, so you will be told rather than
+debug it. Two of them need context:
 
 - **Zephyr Settings.** `CONFIG_SETTINGS_NVS` is rejected — the SoftSIM needs the
   `nvs_storage` partition. Switching to `CONFIG_SETTINGS_FCB=y` (or ZMS) is not enough on
@@ -224,6 +224,27 @@ rather than debug it. Two of them need context:
 - **MCUboot on the DKs.** Enabling it without switching to the MCUboot partition layout
   leaves the devicetree with no `boot_partition`; add the overlay
   [above](#flash-partitioning).
+
+### Migrating from 6.1.0 and earlier
+
+SoftSIM used to set `CONFIG_HEAP_MEM_POOL_SIZE=30000` in `overlay-softsim.conf`, so
+applying the overlay handed your application a 30 kB kernel heap it could allocate from.
+SoftSIM now allocates from its own heap and no longer sets yours.
+
+If your application calls `k_malloc` — directly, or through a library such as nRF Cloud,
+nRF Provisioning or FOTA — declare your own `CONFIG_HEAP_MEM_POOL_SIZE`. The symptom of
+missing this is an allocation that used to succeed returning NULL, often inside library
+code rather than your own. [`samples/softsim_external_profile/prj.conf`](../samples/softsim_external_profile/prj.conf)
+shows the one-line declaration.
+
+### Measuring the heap
+
+Build with `CONFIG_SOFTSIM_HEAP_STATS=y` and SoftSIM logs how much of
+`CONFIG_SOFTSIM_HEAP_SIZE` it has used whenever the modem deinitialises the SIM. Exercise
+an RFM/OTA exchange that returns a large response before trusting a peak: that path alone
+allocates about 10 kB more than steady state, and provisioning plus attach never reaches
+it. The figure is a high-water mark, not a largest-free-block, so it says nothing about
+fragmentation.
 
 Two more that no assert catches: some applications (e.g. `modem_shell`) fail to link with
 `... uses VFP register arguments` — add `CONFIG_FP_SOFTABI=y`. And the crypto port needs
@@ -240,9 +261,11 @@ Two more that no assert catches: some applications (e.g. `modem_shell`) fail to 
   the profile. Plan the address to be stable across your product's DFU history — the
   shipped layouts are address-compatible with older Partition Manager releases for exactly
   this reason.
-- **Memory**: `port_malloc`/`port_free` map to `k_malloc`/`k_free`. Point them at a
-  dedicated `k_heap` to isolate the SoftSIM's ~30 kB from your application's heap
-  accounting.
+- **Memory**: `port_malloc`/`port_free` own a private `k_heap` sized by
+  `CONFIG_SOFTSIM_HEAP_SIZE`, which is what keeps SoftSIM's memory and the application's
+  from reaching each other. A port must stay non-blocking (the modem request handler calls
+  it) and must keep `malloc`'s contract of returning a usable pointer for a zero-length
+  request.
 
 Three hazards worth knowing:
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -239,12 +239,15 @@ shows the one-line declaration.
 
 ### Measuring the heap
 
-Build with `CONFIG_SOFTSIM_HEAP_STATS=y` and SoftSIM logs how much of
-`CONFIG_SOFTSIM_HEAP_SIZE` it has used whenever the modem deinitialises the SIM. Exercise
-an RFM/OTA exchange that returns a large response before trusting a peak: that path alone
+Build with `CONFIG_SOFTSIM_HEAP_STATS=y` — the sample carries
+[`overlay-heap-stats.conf`](../samples/softsim_external_profile/overlay-heap-stats.conf)
+for this — and SoftSIM logs its high-water mark each time it grows, naming the INS byte
+of the APDU that caused it (`INS 0x00` means the peak grew outside an APDU). Exercise an
+RFM/OTA exchange that returns a large response before trusting a peak: that path alone
 allocates about 10 kB more than steady state, and provisioning plus attach never reaches
 it. The figure is a high-water mark, not a largest-free-block, so it says nothing about
-fragmentation.
+fragmentation, and because it only reports on growth a leak stays invisible until it
+exceeds the peak.
 
 Two more that no assert catches: some applications (e.g. `modem_shell`) fail to link with
 `... uses VFP register arguments` — add `CONFIG_FP_SOFTABI=y`. And the crypto port needs

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -225,17 +225,24 @@ debug it. Two of them need context:
   leaves the devicetree with no `boot_partition`; add the overlay
   [above](#flash-partitioning).
 
-### Migrating from 6.1.0 and earlier
+### Migrating from 6.1.1 and earlier
 
 SoftSIM used to set `CONFIG_HEAP_MEM_POOL_SIZE=30000` in `overlay-softsim.conf`, so
-applying the overlay handed your application a 30 kB kernel heap it could allocate from.
-SoftSIM now allocates from its own heap and no longer sets yours.
+applying the overlay handed your application a 30 kB kernel heap it could allocate from,
+and a build assert required that value even if you set it yourself. SoftSIM now allocates
+from its own heap and no longer sets or requires yours. Two things to check:
 
-If your application calls `k_malloc` — directly, or through a library such as nRF Cloud,
-nRF Provisioning or FOTA — declare your own `CONFIG_HEAP_MEM_POOL_SIZE`. The symptom of
-missing this is an allocation that used to succeed returning NULL, often inside library
-code rather than your own. [`samples/softsim_external_profile/prj.conf`](../samples/softsim_external_profile/prj.conf)
-shows the one-line declaration.
+- **Do you still need a kernel heap?** If your application calls `k_malloc` — directly, or
+  through a library such as nRF Cloud, nRF Provisioning or FOTA — declare your own
+  `CONFIG_HEAP_MEM_POOL_SIZE`, sized for your use rather than SoftSIM's.
+  [`samples/softsim_external_profile/prj.conf`](../samples/softsim_external_profile/prj.conf)
+  shows the one-line declaration. The symptom of missing this is an allocation that used to
+  succeed returning NULL, often inside library code rather than your own. Zephyr defaults
+  the pool to 0, so nothing warns you.
+- **Is the value you have left over from SoftSIM?** CMake warns at configure time when
+  `CONFIG_HEAP_MEM_POOL_SIZE` is 30000 or more, since that is almost always the old
+  mandated value rather than a measured one. Delete it, or lower it to what your
+  application actually allocates — the private heap is charged on top of it.
 
 ### Measuring the heap
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -55,6 +55,8 @@ file(MAKE_DIRECTORY ${_softsim_install_dir})
 
 # Set default option values in one place.
 _softsim_set_uicc_bool(CONFIG_ENABLE_SANITIZE CONFIG_SOFTSIM_UICC_ENABLE_SANITIZE OFF "Enable -fsanitize in onomondo-uicc build")
+# Pinned off: SoftSIM owns its heap (lib/ss_heap.c), so the core has to use
+# the port allocator. Deliberately no Kconfig symbol to flip it.
 _softsim_set_uicc_bool(CONFIG_USE_SYSTEM_HEAP CONFIG_SOFTSIM_UICC_USE_SYSTEM_HEAP OFF "Use system malloc/free in onomondo-uicc")
 _softsim_set_uicc_bool(CONFIG_USE_LOGS CONFIG_SOFTSIM_UICC_USE_LOGS ON "Enable ss_logp logging in onomondo-uicc")
 _softsim_set_uicc_bool(CONFIG_USE_EXPERIMENTAL_SUSPEND_COMMAND CONFIG_SOFTSIM_UICC_USE_EXPERIMENTAL_SUSPEND_COMMAND ON "Enable experimental suspend command in onomondo-uicc")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -55,8 +55,6 @@ file(MAKE_DIRECTORY ${_softsim_install_dir})
 
 # Set default option values in one place.
 _softsim_set_uicc_bool(CONFIG_ENABLE_SANITIZE CONFIG_SOFTSIM_UICC_ENABLE_SANITIZE OFF "Enable -fsanitize in onomondo-uicc build")
-# Pinned off: SoftSIM owns its heap (lib/ss_heap.c), so the core has to use
-# the port allocator. Deliberately no Kconfig symbol to flip it.
 _softsim_set_uicc_bool(CONFIG_USE_SYSTEM_HEAP CONFIG_SOFTSIM_UICC_USE_SYSTEM_HEAP OFF "Use system malloc/free in onomondo-uicc")
 _softsim_set_uicc_bool(CONFIG_USE_LOGS CONFIG_SOFTSIM_UICC_USE_LOGS ON "Enable ss_logp logging in onomondo-uicc")
 _softsim_set_uicc_bool(CONFIG_USE_EXPERIMENTAL_SUSPEND_COMMAND CONFIG_SOFTSIM_UICC_USE_EXPERIMENTAL_SUSPEND_COMMAND ON "Enable experimental suspend command in onomondo-uicc")

--- a/lib/build_asserts.c
+++ b/lib/build_asserts.c
@@ -10,19 +10,12 @@
 #include <onomondo/utils/ss_profile.h>
 
 #define EXPECTED_PARTITION_SIZE 0x8000
-#define EXPECTED_MIN_HEAP_SIZE  30000
 
 /* nrf_softsim_provision() validates the parsed profile by indexing the KI/OPc pair in
  * A001 and the KIC/KID pair in A004. Pin those layouts so a submodule bump that moves
  * them fails the build instead of silently reading the wrong bytes. */
 BUILD_ASSERT(2 * KEY_SIZE <= A001_LEN, "SoftSIM: A001 layout changed");
 BUILD_ASSERT(A004_HEADER_SIZE + 2 * KEY_SIZE <= A004_LEN, "SoftSIM: A004 layout changed");
-
-/* Effective heap size (includes the ADD_SIZE contributions); only trips when
- * HEAP_MEM_POOL_IGNORE_MIN bypasses them. */
-BUILD_ASSERT(K_HEAP_MEM_POOL_SIZE >= EXPECTED_MIN_HEAP_SIZE, "SoftSIM: "
-							     "Heap memory pool size is not valid. "
-							     "Please reconfigure the project.");
 
 /* In NCS, when NVS backend for Settings is chosen, `nvs_partition` partition is not included by
  * the Partition Manager.

--- a/lib/build_asserts.c
+++ b/lib/build_asserts.c
@@ -18,10 +18,11 @@
 BUILD_ASSERT(2 * KEY_SIZE <= A001_LEN, "SoftSIM: A001 layout changed");
 BUILD_ASSERT(A004_HEADER_SIZE + 2 * KEY_SIZE <= A004_LEN, "SoftSIM: A004 layout changed");
 
-BUILD_ASSERT(CONFIG_HEAP_MEM_POOL_SIZE >= EXPECTED_MIN_HEAP_SIZE,
-	     "SoftSIM: "
-	     "Heap memory pool size is not valid. "
-	     "Please reconfigure the project.");
+/* Effective heap size (includes the ADD_SIZE contributions); only trips when
+ * HEAP_MEM_POOL_IGNORE_MIN bypasses them. */
+BUILD_ASSERT(K_HEAP_MEM_POOL_SIZE >= EXPECTED_MIN_HEAP_SIZE, "SoftSIM: "
+							     "Heap memory pool size is not valid. "
+							     "Please reconfigure the project.");
 
 /* In NCS, when NVS backend for Settings is chosen, `nvs_partition` partition is not included by
  * the Partition Manager.

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -228,8 +228,7 @@ static void softsim_req_task(struct k_work *item)
 	struct softsim_req_node *s_req;
 
 	while ((s_req = k_fifo_get(&softsim_req_fifo, K_NO_WAIT))) {
-		/* Captured before the node is freed: names the command that drove a
-		 * new heap peak. */
+		/* Captured before the node is freed, to name the command in the peak log. */
 		uint8_t ins = 0;
 
 		if (s_req->req == NRF_MODEM_SOFTSIM_APDU && s_req->payload.data &&

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -24,10 +24,9 @@
 LOG_MODULE_REGISTER(softsim, CONFIG_SOFTSIM_NRF_LOG_LEVEL);
 
 /* SoftSIM memory configuration */
-#define SOFTSIM_STACK_SIZE 10000 /* TODO: Figure out some more reasonable value. */
-#define SOFTSIM_PRIORITY   5     /* TODO: What is a good balance here? */
+#define SOFTSIM_PRIORITY 5 /* TODO: What is a good balance here? */
 
-K_THREAD_STACK_DEFINE(softsim_stack_area, SOFTSIM_STACK_SIZE);
+K_THREAD_STACK_DEFINE(softsim_stack_area, CONFIG_SOFTSIM_STACK_SIZE);
 
 #define SIM_HAL_MAX_LE 260
 

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -10,6 +10,7 @@
 #include <zephyr/logging/log.h>
 
 #include "ss_crypto.h"
+#include "ss_heap.h"
 #include <nrf_softsim.h>
 #include <nrf_modem_at.h>
 #include <nrf_modem_softsim.h>
@@ -279,6 +280,8 @@ static void softsim_req_task(struct k_work *item)
 			} else {
 				LOG_DBG("SoftSIM suspended. Keeping context.");
 			}
+
+			ss_heap_log_stats();
 
 			err = nrf_modem_softsim_res(s_req->req, s_req->req_id, NULL, 0);
 			if (err) {

--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -228,6 +228,15 @@ static void softsim_req_task(struct k_work *item)
 	struct softsim_req_node *s_req;
 
 	while ((s_req = k_fifo_get(&softsim_req_fifo, K_NO_WAIT))) {
+		/* Captured before the node is freed: names the command that drove a
+		 * new heap peak. */
+		uint8_t ins = 0;
+
+		if (s_req->req == NRF_MODEM_SOFTSIM_APDU && s_req->payload.data &&
+		    s_req->payload.data_len > 1) {
+			ins = ((const uint8_t *)s_req->payload.data)[1];
+		}
+
 		switch (s_req->req) {
 		case NRF_MODEM_SOFTSIM_INIT: {
 			LOG_DBG("SoftSIM INIT REQ");
@@ -281,8 +290,6 @@ static void softsim_req_task(struct k_work *item)
 				LOG_DBG("SoftSIM suspended. Keeping context.");
 			}
 
-			ss_heap_log_stats();
-
 			err = nrf_modem_softsim_res(s_req->req, s_req->req_id, NULL, 0);
 			if (err) {
 				LOG_ERR("SoftSIM DEINIT response failed with err: %d", err);
@@ -316,6 +323,8 @@ static void softsim_req_task(struct k_work *item)
 
 		/* Free the request node */
 		port_free(s_req);
+
+		ss_heap_log_stats(ins);
 	}
 }
 

--- a/lib/ss_heap.c
+++ b/lib/ss_heap.c
@@ -7,6 +7,11 @@
 
 #include <onomondo/softsim/mem.h>
 
+/* SoftSIM's own heap: the application cannot allocate from it, and SoftSIM does
+ * not allocate from the application's. Wrapped like the kernel wraps the system
+ * heap, so the Kconfig value means usable bytes. */
+K_HEAP_DEFINE(softsim_port_heap, Z_HEAP_MIN_SIZE_FOR(CONFIG_SOFTSIM_HEAP_SIZE));
+
 /**
  * @brief Custom allocator
  *
@@ -16,7 +21,9 @@
  */
 void *port_malloc(size_t size)
 {
-	return k_malloc(size);
+	/* K_NO_WAIT: reachable from the modem request handler. size ? size : 1
+	 * keeps k_malloc's contract, which never passed a zero size on. */
+	return k_heap_alloc(&softsim_port_heap, size ? size : 1, K_NO_WAIT);
 }
 
 /**
@@ -26,5 +33,5 @@ void *port_malloc(size_t size)
  */
 void port_free(void *ptr)
 {
-	k_free(ptr);
+	k_heap_free(&softsim_port_heap, ptr);
 }

--- a/lib/ss_heap.c
+++ b/lib/ss_heap.c
@@ -44,16 +44,23 @@ void port_free(void *ptr)
 /* Registered by nrf_softsim.c, which is always in the image when this is on. */
 LOG_MODULE_DECLARE(softsim, CONFIG_SOFTSIM_NRF_LOG_LEVEL);
 
-void ss_heap_log_stats(void)
+void ss_heap_log_stats(uint8_t ins)
 {
+	/* Only the SoftSIM work queue calls this, so the static needs no lock. */
+	static size_t logged_peak;
 	struct sys_memory_stats stats;
 
 	sys_heap_runtime_stats_get(&softsim_port_heap.heap, &stats);
 
-	/* max_allocated_bytes is a high-water mark, not a largest-free-block:
-	 * it does not show fragmentation. */
-	LOG_INF("SoftSIM heap: %zu used, %zu peak, %zu free of %d configured",
-		stats.allocated_bytes, stats.max_allocated_bytes, stats.free_bytes,
-		CONFIG_SOFTSIM_HEAP_SIZE);
+	if (stats.max_allocated_bytes <= logged_peak) {
+		return;
+	}
+	logged_peak = stats.max_allocated_bytes;
+
+	/* A high-water mark, not a largest-free-block: it does not show
+	 * fragmentation. INS 0x00 means the peak grew outside an APDU. */
+	LOG_INF("SoftSIM heap: new peak %zu of %d configured, INS 0x%02x (%zu used, %zu free)",
+		stats.max_allocated_bytes, CONFIG_SOFTSIM_HEAP_SIZE, ins, stats.allocated_bytes,
+		stats.free_bytes);
 }
 #endif

--- a/lib/ss_heap.c
+++ b/lib/ss_heap.c
@@ -11,9 +11,8 @@
 
 #include "ss_heap.h"
 
-/* SoftSIM's own heap: the application cannot allocate from it, and SoftSIM does
- * not allocate from the application's. Wrapped like the kernel wraps the system
- * heap, so the Kconfig value means usable bytes. */
+/* SoftSIM's own heap: neither side can allocate from the other's. Wrapped like
+ * the kernel wraps the system heap, so the Kconfig value means usable bytes. */
 K_HEAP_DEFINE(softsim_port_heap, Z_HEAP_MIN_SIZE_FOR(CONFIG_SOFTSIM_HEAP_SIZE));
 
 /**
@@ -25,8 +24,8 @@ K_HEAP_DEFINE(softsim_port_heap, Z_HEAP_MIN_SIZE_FOR(CONFIG_SOFTSIM_HEAP_SIZE));
  */
 void *port_malloc(size_t size)
 {
-	/* K_NO_WAIT: reachable from the modem request handler. size ? size : 1
-	 * keeps k_malloc's contract, which never passed a zero size on. */
+	/* K_NO_WAIT: runs in the modem request handler. size ? size : 1 keeps
+	 * k_malloc's contract of never passing a zero size on. */
 	return k_heap_alloc(&softsim_port_heap, size ? size : 1, K_NO_WAIT);
 }
 
@@ -57,8 +56,7 @@ void ss_heap_log_stats(uint8_t ins)
 	}
 	logged_peak = stats.max_allocated_bytes;
 
-	/* A high-water mark, not a largest-free-block: it does not show
-	 * fragmentation. INS 0x00 means the peak grew outside an APDU. */
+	/* A high-water mark, so it cannot show fragmentation. INS 0 = not an APDU. */
 	LOG_INF("SoftSIM heap: new peak %zu of %d configured, INS 0x%02x (%zu used, %zu free)",
 		stats.max_allocated_bytes, CONFIG_SOFTSIM_HEAP_SIZE, ins, stats.allocated_bytes,
 		stats.free_bytes);

--- a/lib/ss_heap.c
+++ b/lib/ss_heap.c
@@ -4,8 +4,12 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/mem_stats.h>
 
 #include <onomondo/softsim/mem.h>
+
+#include "ss_heap.h"
 
 /* SoftSIM's own heap: the application cannot allocate from it, and SoftSIM does
  * not allocate from the application's. Wrapped like the kernel wraps the system
@@ -35,3 +39,21 @@ void port_free(void *ptr)
 {
 	k_heap_free(&softsim_port_heap, ptr);
 }
+
+#if defined(CONFIG_SOFTSIM_HEAP_STATS)
+/* Registered by nrf_softsim.c, which is always in the image when this is on. */
+LOG_MODULE_DECLARE(softsim, CONFIG_SOFTSIM_NRF_LOG_LEVEL);
+
+void ss_heap_log_stats(void)
+{
+	struct sys_memory_stats stats;
+
+	sys_heap_runtime_stats_get(&softsim_port_heap.heap, &stats);
+
+	/* max_allocated_bytes is a high-water mark, not a largest-free-block:
+	 * it does not show fragmentation. */
+	LOG_INF("SoftSIM heap: %zu used, %zu peak, %zu free of %d configured",
+		stats.allocated_bytes, stats.max_allocated_bytes, stats.free_bytes,
+		CONFIG_SOFTSIM_HEAP_SIZE);
+}
+#endif

--- a/lib/ss_heap.h
+++ b/lib/ss_heap.h
@@ -9,8 +9,7 @@
 #include <stdint.h>
 
 #if defined(CONFIG_SOFTSIM_HEAP_STATS)
-/* Logs the private heap when its peak grows. `ins` is the INS byte of the APDU
- * just handled, or 0 if the request was not an APDU. */
+/* Logs the private heap when its peak grows. `ins` is the APDU's INS byte, or 0. */
 void ss_heap_log_stats(uint8_t ins);
 #else
 static inline void ss_heap_log_stats(uint8_t ins)

--- a/lib/ss_heap.h
+++ b/lib/ss_heap.h
@@ -6,12 +6,16 @@
 #ifndef _SS_HEAP_H_
 #define _SS_HEAP_H_
 
+#include <stdint.h>
+
 #if defined(CONFIG_SOFTSIM_HEAP_STATS)
-/* Logs how much of the private heap SoftSIM has used. */
-void ss_heap_log_stats(void);
+/* Logs the private heap when its peak grows. `ins` is the INS byte of the APDU
+ * just handled, or 0 if the request was not an APDU. */
+void ss_heap_log_stats(uint8_t ins);
 #else
-static inline void ss_heap_log_stats(void)
+static inline void ss_heap_log_stats(uint8_t ins)
 {
+	(void)ins;
 }
 #endif
 

--- a/lib/ss_heap.h
+++ b/lib/ss_heap.h
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 Onomondo ApS
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+#ifndef _SS_HEAP_H_
+#define _SS_HEAP_H_
+
+#if defined(CONFIG_SOFTSIM_HEAP_STATS)
+/* Logs how much of the private heap SoftSIM has used. */
+void ss_heap_log_stats(void);
+#else
+static inline void ss_heap_log_stats(void)
+{
+}
+#endif
+
+#endif /* _SS_HEAP_H_ */

--- a/overlay-softsim.conf
+++ b/overlay-softsim.conf
@@ -18,8 +18,9 @@ CONFIG_FLASH_MAP=y
 CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
-# Stack and heap sizing lives in Kconfig defaults (see Kconfig) so an
-# application prj.conf can override it.
+# Auto-init runs SoftSIM fs init on the main stack (SYS_INIT); hard assignment
+# so a smaller application value can't overflow it. Heap sizing: see Kconfig.
+CONFIG_MAIN_STACK_SIZE=5000
 
 # TF-M Configurations
 CONFIG_BUILD_WITH_TFM=y

--- a/overlay-softsim.conf
+++ b/overlay-softsim.conf
@@ -18,9 +18,8 @@ CONFIG_FLASH_MAP=y
 CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
-# Stack and Heap Configurations
-CONFIG_MAIN_STACK_SIZE=5000
-CONFIG_HEAP_MEM_POOL_SIZE=30000
+# Stack and heap sizing lives in Kconfig defaults (see Kconfig) so an
+# application prj.conf can override it.
 
 # TF-M Configurations
 CONFIG_BUILD_WITH_TFM=y

--- a/overlay-softsim.conf
+++ b/overlay-softsim.conf
@@ -18,9 +18,13 @@ CONFIG_FLASH_MAP=y
 CONFIG_FLASH_PAGE_LAYOUT=y
 CONFIG_MPU_ALLOW_FLASH_WRITE=y
 
-# Auto-init runs SoftSIM fs init on the main stack (SYS_INIT); hard assignment
-# so a smaller application value can't overflow it. Heap sizing: see Kconfig.
+# Auto-init runs SoftSIM fs init on the main stack (SYS_INIT); a hard
+# assignment, so it overrides the application's value in both directions.
 CONFIG_MAIN_STACK_SIZE=5000
+
+# No CONFIG_HEAP_MEM_POOL_SIZE here on purpose: SoftSIM allocates from its own
+# heap (CONFIG_SOFTSIM_HEAP_SIZE). The kernel heap is yours to declare if your
+# application uses k_malloc -- see docs/integration.md.
 
 # TF-M Configurations
 CONFIG_BUILD_WITH_TFM=y

--- a/overlay-softsim.conf
+++ b/overlay-softsim.conf
@@ -22,9 +22,8 @@ CONFIG_MPU_ALLOW_FLASH_WRITE=y
 # assignment, so it overrides the application's value in both directions.
 CONFIG_MAIN_STACK_SIZE=5000
 
-# No CONFIG_HEAP_MEM_POOL_SIZE here on purpose: SoftSIM allocates from its own
-# heap (CONFIG_SOFTSIM_HEAP_SIZE). The kernel heap is yours to declare if your
-# application uses k_malloc -- see docs/integration.md.
+# No CONFIG_HEAP_MEM_POOL_SIZE on purpose: SoftSIM allocates from its own
+# CONFIG_SOFTSIM_HEAP_SIZE. Declare your own if your application uses k_malloc.
 
 # TF-M Configurations
 CONFIG_BUILD_WITH_TFM=y

--- a/samples/softsim_external_profile/overlay-heap-stats.conf
+++ b/samples/softsim_external_profile/overlay-heap-stats.conf
@@ -1,0 +1,5 @@
+# Heap measurement overlay: logs SoftSIM's private heap each time its peak grows,
+# naming the APDU that caused it. Needed to justify any CONFIG_SOFTSIM_HEAP_SIZE
+# below the default -- see docs/integration.md, "Measuring the heap".
+# Build with: west build --sysbuild -b <board> -- -DEXTRA_CONF_FILE=overlay-heap-stats.conf
+CONFIG_SOFTSIM_HEAP_STATS=y

--- a/samples/softsim_external_profile/overlay-heap-stats.conf
+++ b/samples/softsim_external_profile/overlay-heap-stats.conf
@@ -1,5 +1,3 @@
-# Heap measurement overlay: logs SoftSIM's private heap each time its peak grows,
-# naming the APDU that caused it. Needed to justify any CONFIG_SOFTSIM_HEAP_SIZE
-# below the default -- see docs/integration.md, "Measuring the heap".
-# Build with: west build --sysbuild -b <board> -- -DEXTRA_CONF_FILE=overlay-heap-stats.conf
+# Logs SoftSIM's private heap each time its peak grows, naming the APDU.
+# Build: west build --sysbuild -b <board> -- -DEXTRA_CONF_FILE=overlay-heap-stats.conf
 CONFIG_SOFTSIM_HEAP_STATS=y

--- a/samples/softsim_external_profile/prj.conf
+++ b/samples/softsim_external_profile/prj.conf
@@ -39,6 +39,10 @@ CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_LC_PSM_MODULE=y
 CONFIG_LTE_LC_EDRX_MODULE=y
 
+# This application's own kernel heap, for the profile buffer in main.c. SoftSIM
+# does not set it: it allocates from CONFIG_SOFTSIM_HEAP_SIZE instead.
+CONFIG_HEAP_MEM_POOL_SIZE=2048
+
 # AT host library
 CONFIG_SERIAL=y
 CONFIG_AT_HOST_LIBRARY=y

--- a/samples/softsim_external_profile/prj.conf
+++ b/samples/softsim_external_profile/prj.conf
@@ -39,8 +39,9 @@ CONFIG_LTE_LINK_CONTROL=y
 CONFIG_LTE_LC_PSM_MODULE=y
 CONFIG_LTE_LC_EDRX_MODULE=y
 
-# This application's own kernel heap, for the profile buffer in main.c. SoftSIM
-# does not set it: it allocates from CONFIG_SOFTSIM_HEAP_SIZE instead.
+# Kernel heap for this application's own allocation: the profile buffer in
+# main.c. SoftSIM does not set CONFIG_HEAP_MEM_POOL_SIZE -- it allocates from
+# CONFIG_SOFTSIM_HEAP_SIZE -- so sizing this one is the application's job.
 CONFIG_HEAP_MEM_POOL_SIZE=2048
 
 # AT host library

--- a/samples/softsim_external_profile/src/main.c
+++ b/samples/softsim_external_profile/src/main.c
@@ -165,7 +165,11 @@ static int provision_softsim_from_serial(void)
 	}
 
 	char *profile = k_malloc(PROFILE_MAX_SIZE);
-	__ASSERT_NO_MSG(profile != NULL);
+
+	if (profile == NULL) {
+		LOG_ERR("Out of heap for the profile buffer; raise CONFIG_HEAP_MEM_POOL_SIZE");
+		return -1;
+	}
 
 	struct rx_buf_t rx = {
 		.buf = profile,

--- a/tests/apdu/prj.conf
+++ b/tests/apdu/prj.conf
@@ -7,8 +7,12 @@ CONFIG_FLASH_SIMULATOR=y
 CONFIG_NVS=y
 
 # The UICC core allocates its context, file buffers and the directory cache
-# through the port heap (SS_ALLOC -> port_malloc -> k_malloc).
-CONFIG_HEAP_MEM_POOL_SIZE=65536
+# through the port heap (SS_ALLOC -> port_malloc -> SoftSIM's own k_heap).
+CONFIG_SOFTSIM_HEAP_SIZE=65536
+
+# Test-only: per-chunk canaries. k_free used to find the owning heap from a tag
+# it wrote itself; k_heap_free trusts the pointer, so catch bad frees here.
+CONFIG_SYS_HEAP_HARDENING_FULL=y
 
 # Repeat counts pinned to 1; see tests/fs/prj.conf for why the defaults hurt.
 CONFIG_ZTEST_SHUFFLE=y

--- a/tests/apdu/prj.conf
+++ b/tests/apdu/prj.conf
@@ -10,8 +10,7 @@ CONFIG_NVS=y
 # through the port heap (SS_ALLOC -> port_malloc -> SoftSIM's own k_heap).
 CONFIG_SOFTSIM_HEAP_SIZE=65536
 
-# Test-only: per-chunk canaries. k_free used to find the owning heap from a tag
-# it wrote itself; k_heap_free trusts the pointer, so catch bad frees here.
+# Test-only per-chunk canaries: k_heap_free trusts the pointer, k_free did not.
 CONFIG_SYS_HEAP_HARDENING_FULL=y
 
 # Repeat counts pinned to 1; see tests/fs/prj.conf for why the defaults hurt.

--- a/tests/apdu/src/main.c
+++ b/tests/apdu/src/main.c
@@ -25,6 +25,7 @@
 #include <zephyr/ztest.h>
 
 #include <nrf_softsim.h>
+#include <onomondo/softsim/mem.h>
 #include <onomondo/softsim/softsim.h>
 
 /* ss_fs.c does LOG_MODULE_DECLARE(softsim, ...); register it once here.
@@ -284,4 +285,17 @@ ZTEST(softsim_apdu, test_authenticate_rejects_a_forged_mac)
 	len = transact(authenticate, sizeof(authenticate), rsp);
 	expect_sw(rsp, len, 0x9862, "AUTHENTICATE with a forged MAC");
 	zassert_equal(len, 2, "a rejected AUTHENTICATE must carry no response data");
+}
+
+/* The port allocator replaced k_malloc, which never passed a zero size on to
+ * the allocator and tolerated a NULL free. A zero-length READ BINARY reaches
+ * SS_ALLOC_N(0), so a plain k_heap_alloc would turn that into an error. */
+ZTEST(softsim_apdu, test_port_allocator_keeps_the_malloc_contract)
+{
+	void *zero = port_malloc(0);
+
+	zassert_not_null(zero, "port_malloc(0) must not fail");
+	port_free(zero);
+
+	port_free(NULL);
 }

--- a/tests/apdu/src/main.c
+++ b/tests/apdu/src/main.c
@@ -287,9 +287,8 @@ ZTEST(softsim_apdu, test_authenticate_rejects_a_forged_mac)
 	zassert_equal(len, 2, "a rejected AUTHENTICATE must carry no response data");
 }
 
-/* The port allocator replaced k_malloc, which never passed a zero size on to
- * the allocator and tolerated a NULL free. A zero-length READ BINARY reaches
- * SS_ALLOC_N(0), so a plain k_heap_alloc would turn that into an error. */
+/* k_malloc never passed a zero size on and tolerated a NULL free. A zero-length
+ * READ BINARY reaches SS_ALLOC_N(0), which a plain k_heap_alloc would reject. */
 ZTEST(softsim_apdu, test_port_allocator_keeps_the_malloc_contract)
 {
 	void *zero = port_malloc(0);

--- a/tests/cache/CMakeLists.txt
+++ b/tests/cache/CMakeLists.txt
@@ -25,6 +25,5 @@ target_include_directories(app PRIVATE
 # `if SOFTSIM`, so autoconf.h already defines them in any workspace build. This
 # -D only survives because 3 is exactly the value autoconf derives from
 # LOG_DEFAULT_LEVEL; a different value would be a macro-redefinition error.
-# The heap follows the production path (SS_ALLOC -> port_malloc -> SoftSIM's
-# own k_heap) because ss_heap.c is compiled in above.
+# ss_heap.c is compiled in above, so the heap follows the production path.
 target_compile_definitions(app PRIVATE CONFIG_SOFTSIM_NRF_LOG_LEVEL=3)

--- a/tests/cache/CMakeLists.txt
+++ b/tests/cache/CMakeLists.txt
@@ -25,6 +25,6 @@ target_include_directories(app PRIVATE
 # `if SOFTSIM`, so autoconf.h already defines them in any workspace build. This
 # -D only survives because 3 is exactly the value autoconf derives from
 # LOG_DEFAULT_LEVEL; a different value would be a macro-redefinition error.
-# The heap follows the production path (SS_ALLOC -> port_malloc -> k_malloc)
-# because ss_heap.c is compiled in above.
+# The heap follows the production path (SS_ALLOC -> port_malloc -> SoftSIM's
+# own k_heap) because ss_heap.c is compiled in above.
 target_compile_definitions(app PRIVATE CONFIG_SOFTSIM_NRF_LOG_LEVEL=3)

--- a/tests/cache/prj.conf
+++ b/tests/cache/prj.conf
@@ -1,8 +1,7 @@
 CONFIG_ZTEST=y
 CONFIG_ASSERT=y
 
-# No CONFIG_HEAP_MEM_POOL_SIZE: ss_heap.c allocates from SoftSIM's own heap,
-# and CONFIG_SOFTSIM_HEAP_SIZE defaults to more than this suite needs.
+# No CONFIG_HEAP_MEM_POOL_SIZE: ss_heap.c allocates from SoftSIM's own heap.
 
 # Shuffle catches state leaking between tests -- the characteristic failure of a
 # cache/storage suite. The repeat counts default to 3 each, which multiplies out

--- a/tests/cache/prj.conf
+++ b/tests/cache/prj.conf
@@ -1,8 +1,8 @@
 CONFIG_ZTEST=y
 CONFIG_ASSERT=y
 
-# ss_heap.c routes SS_ALLOC through k_malloc, so the tests need a kernel heap.
-CONFIG_HEAP_MEM_POOL_SIZE=16384
+# No CONFIG_HEAP_MEM_POOL_SIZE: ss_heap.c allocates from SoftSIM's own heap,
+# and CONFIG_SOFTSIM_HEAP_SIZE defaults to more than this suite needs.
 
 # Shuffle catches state leaking between tests -- the characteristic failure of a
 # cache/storage suite. The repeat counts default to 3 each, which multiplies out

--- a/tests/crypto/prj.conf
+++ b/tests/crypto/prj.conf
@@ -1,8 +1,7 @@
 CONFIG_ZTEST=y
 CONFIG_ASSERT=y
 
-# ss_heap.c routes SS_ALLOC through k_malloc.
-CONFIG_HEAP_MEM_POOL_SIZE=16384
+# No CONFIG_HEAP_MEM_POOL_SIZE: ss_heap.c allocates from SoftSIM's own heap.
 
 # PSA crypto, provided off-target by Mbed TLS rather than TF-M. The algorithm
 # set is what ss_crypto.c asks for: AES-CBC without padding for the cipher

--- a/tests/fs/prj.conf
+++ b/tests/fs/prj.conf
@@ -9,8 +9,7 @@ CONFIG_NVS=y
 # ss_fs.c caches file contents on SoftSIM's own heap via ss_heap.c.
 CONFIG_SOFTSIM_HEAP_SIZE=32768
 
-# Test-only: per-chunk canaries. k_free used to find the owning heap from a tag
-# it wrote itself; k_heap_free trusts the pointer, so catch bad frees here.
+# Test-only per-chunk canaries: k_heap_free trusts the pointer, k_free did not.
 CONFIG_SYS_HEAP_HARDENING_FULL=y
 
 # A storage cache is exactly the kind of code that leaks state between tests.

--- a/tests/fs/prj.conf
+++ b/tests/fs/prj.conf
@@ -6,8 +6,12 @@ CONFIG_FLASH_MAP=y
 CONFIG_FLASH_SIMULATOR=y
 CONFIG_NVS=y
 
-# ss_fs.c caches file contents on the kernel heap via ss_heap.c.
-CONFIG_HEAP_MEM_POOL_SIZE=32768
+# ss_fs.c caches file contents on SoftSIM's own heap via ss_heap.c.
+CONFIG_SOFTSIM_HEAP_SIZE=32768
+
+# Test-only: per-chunk canaries. k_free used to find the owning heap from a tag
+# it wrote itself; k_heap_free trusts the pointer, so catch bad frees here.
+CONFIG_SYS_HEAP_HARDENING_FULL=y
 
 # A storage cache is exactly the kind of code that leaks state between tests.
 # Repeat counts pinned to 1: their default of 3 each would re-run every case nine


### PR DESCRIPTION
SoftSIM allocates from a private `k_heap` sized by `CONFIG_SOFTSIM_HEAP_SIZE` (default 30000) instead of the shared kernel pool. A contribution cannot reserve anything: `final_heap_size = max(CONFIG_HEAP_MEM_POOL_SIZE, add_size_sum)`, so an application's own request and ours do not add, the larger just wins.

Breaking: applications no longer inherit a 30 kB kernel heap from `overlay-softsim.conf` and must declare their own `CONFIG_HEAP_MEM_POOL_SIZE` if they call `k_malloc`. Migration note in `docs/integration.md`.

Supersedes #188, whose commits are included here; the intermediate `HEAP_MEM_POOL_ADD_SIZE_SOFTSIM` does not appear in the net diff.
