### PR TITLE
refactor: allocate the modem request node through the port allocator

### DIFF
--- a/lib/nrf_softsim.c
+++ b/lib/nrf_softsim.c
@@ -17,6 +17,7 @@
 #include <onomondo/softsim/softsim.h>
 #include <onomondo/softsim/utils.h>
 #include <onomondo/softsim/fs.h>
+#include <onomondo/softsim/mem.h>
 #include <onomondo/utils/ss_profile.h>
 
 /* Logging */
@@ -309,7 +310,7 @@ static void softsim_req_task(struct k_work *item)
 		}
 
 		/* Free the request node */
-		k_free(s_req);
+		port_free(s_req);
 	}
 }
 
@@ -318,7 +319,7 @@ void nrf_modem_softsim_req_handler(enum nrf_modem_softsim_cmd req, uint16_t req_
 {
 	struct softsim_req_node *req_node = NULL;
 
-	req_node = k_malloc(sizeof(struct softsim_req_node));
+	req_node = port_malloc(sizeof(struct softsim_req_node));
 
 	if (!req_node) {
 		LOG_ERR("SoftSIM req_node allocation failed");

--- a/tests/handler/prj.conf
+++ b/tests/handler/prj.conf
@@ -1,6 +1,7 @@
 CONFIG_ZTEST=y
 CONFIG_ASSERT=y
 
-# nrf_softsim.c allocates request nodes with k_malloc and runs its own work queue.
+# For the fake modem payloads below, which are k_malloc'd like the real modem's.
+# nrf_softsim.c itself allocates through the port allocator, faked in main.c.
 CONFIG_HEAP_MEM_POOL_SIZE=16384
 CONFIG_TEST_RANDOM_GENERATOR=y

--- a/tests/handler/src/main.c
+++ b/tests/handler/src/main.c
@@ -22,6 +22,7 @@
 #include <zephyr/ztest.h>
 
 #include <nrf_modem_softsim.h>
+#include <onomondo/softsim/mem.h>
 #include <onomondo/softsim/softsim.h>
 #include <onomondo/utils/ss_profile.h>
 
@@ -54,6 +55,18 @@ FAKE_VALUE_FUNC(int, ss_deinit_fs);
 FAKE_VALUE_FUNC(int, port_provision, struct ss_profile *);
 FAKE_VALUE_FUNC(int, port_check_provisioned);
 FAKE_VALUE_FUNC(int, ss_utils_check_key_existence, enum key_identifier_base);
+
+/* The allocator port (lib/ss_heap.c) is not compiled here. Route to the kernel
+ * heap so allocation stays real and the balance tests keep their meaning. */
+void *port_malloc(size_t size)
+{
+	return k_malloc(size);
+}
+
+void port_free(void *ptr)
+{
+	k_free(ptr);
+}
 
 /*
  * ss_utils_setup_key is declared with a VLA-style parameter, which FFF cannot


### PR DESCRIPTION
The modem request node was the module's only allocation bypassing `port_malloc`/`port_free`, so any change to the allocator silently missed it; no behaviour change, since `port_malloc` is `k_malloc` today.
